### PR TITLE
README.md: Remove wrong statement about LTS presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Versioning
 Next version of `0.x` is `0.(x+1)`. There's no exceptions, or API related meaning
 behind the numbers.
 
-Each versions of stackage (going back 3 stable LTS) has a crypton version
-that we maintain with security fixes when necessary and are versioned with the
-following `0.x.y` scheme.
-
 Coding Style
 ------------
 


### PR DESCRIPTION
Closes #11:

>  Each versions of stackage (going back 3 stable LTS) has a crypton version 

This isn't true. I checked and the first crypton release is in LTS 21. LTS 3 - 20 have a release of cryptonite. (LTS 21 has both crypton and cryptonite.)