### PR TITLE
Strict `byteArray` of `IV c`

### DIFF
--- a/Crypto/Cipher/Types/Block.hs
+++ b/Crypto/Cipher/Types/Block.hs
@@ -50,7 +50,7 @@ import           Foreign.Ptr
 import           Foreign.Storable
 
 -- | an IV parametrized by the cipher
-data IV c = forall byteArray . ByteArray byteArray => IV byteArray
+data IV c = forall byteArray . ByteArray byteArray => IV !byteArray
 
 instance BlockCipher c => ByteArrayAccess (IV c) where
     withByteArray (IV z) f = withByteArray z f


### PR DESCRIPTION
This provides a way to seq `IV c` and its content when client wants to prevent thunk exploding, It's not rare to apply multiple `ivAdd` on single `IV c` and we often don't want thunk here.

About the idea, "using `StrictData`", in our previous discussion, I found that was a very time-consuming job to do if we want to make sure everything still works after change.

Take `Point` for instance
https://github.com/kazu-yamamoto/crypton/blob/50792f18be0ed3b1073439b4d48d344574f727cd/Crypto/ECC/Simple/Types.hs#L105

it has instance of `NFData` but its `Integer` (x and y) field was not marked as strict, which is difficult be to certain that all its user/algorithm never requires these fields to be lazy. And we have more than one type like this.

To reduce the impact, I'll vote for only changing the part I knew that has issue (thunk) and have confidence in solving it in a safer way.