### PR TITLE
Make Digest nominal in its algo type parameter

### DIFF
--- a/Crypto/Hash/Types.hs
+++ b/Crypto/Hash/Types.hs
@@ -97,6 +97,8 @@ newtype Context a = Context Bytes
 newtype Digest a = Digest (Block Word8)
     deriving (Eq,Ord,ByteArrayAccess, Data)
 
+type role Digest nominal
+
 instance NFData (Digest a) where
     rnf (Digest u) = u `deepseq` ()
 


### PR DESCRIPTION
This is to prevent being able to `coerce` between the digests of different algorithms, which is an unsafe operations.

Fixes #26 