### PR TITLE
Request for comments: `pthread` dependency

### DIFF
--- a/crypton.cabal
+++ b/crypton.cabal
@@ -310,9 +310,6 @@ library
     else
         build-depends: base
 
-    if os(linux)
-        extra-libraries: pthread
-
     if flag(old_toolchain_inliner)
         cc-options: -fgnu89-inline
 


### PR DESCRIPTION
> [!NOTE]
> I don't know what the right answer is here. Perhaps this PR should be just be closed as wrong.

In `crypton.cabal` we have

```
if os(linux)
        extra-libraries: pthread
```

This was introduced in https://github.com/haskell-crypto/cryptonite/pull/184 . I don't understand the issue well enough at all, perhaps this is actually required in some setups (perhaps only when the gold linker is used?). However, on my machine at least, this line does not appear to be necessary (both with and without `-threaded`), and https://stackoverflow.com/a/62561519/742991 suggests that `-lpthread` is deprecated.

It's causing some issues in some circumstances (e.g., see my [trace-foreign-calls](https://github.com/well-typed/trace-foreign-calls?tab=readme-ov-file#libphread) plugin), when `ghc` tries to load `crypton` dynamically, resulting in something like

```
<command line>: User-specified static library could not be loaded (/usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libpthread.a)
Loading static libraries is not supported in this configuration.
Try using a dynamic library instead.
```

Related: https://gitlab.haskell.org/ghc/ghc/-/issues/12816 (which _adds_ the dependency, to be clear, not remove it). 