### PR TITLE
Use `-pthread` rather than `-lpthread`

### DIFF
--- a/crypton.cabal
+++ b/crypton.cabal
@@ -311,7 +311,7 @@ library
         build-depends: base
 
     if os(linux)
-        extra-libraries: pthread
+        cc-options: -pthread
 
     if flag(old_toolchain_inliner)
         cc-options: -fgnu89-inline


### PR DESCRIPTION
See https://stackoverflow.com/a/62561519/742991 .

This avoids problems with dynamic loading, errors such as

```
<command line>: User-specified static library could not be loaded (/usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libpthread.a)
Loading static libraries is not supported in this configuration.
Try using a dynamic library instead.
```

I _believe_ that this is the better solution to #32 . I can verify that the code builds with this change, and that it avoids the dynamic linking problem. Unfortunately, I cannot verify if this also solves the problem for which `extra-libraries: pthread` was introduced in the first place; even when I use the gold linker by adding

```
package crypton
  tests: true
  ghc-options: -optl-fuse-ld=gold
  ld-options: -fuse-ld=gold
```

to my `cabal.project` file, the project builds just fine even when `extra-libraries: pthread` and the alternative `cc-options: -pthread` are _both_ not present. 