### PR TITLE
Add TypeOperators language extension to EdDSA.hs

### DIFF
--- a/Crypto/PubKey/EdDSA.hs
+++ b/Crypto/PubKey/EdDSA.hs
@@ -23,6 +23,7 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators #-}
 module Crypto.PubKey.EdDSA
     ( SecretKey
     , PublicKey


### PR DESCRIPTION
I was building with GHC 9.4.8, and there was a warning:

```
 warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
```