### PR TITLE
ECDSA with Public Key Recovery

### DIFF
--- a/Crypto/Number/F2m.hs
+++ b/Crypto/Number/F2m.hs
@@ -24,7 +24,7 @@ module Crypto.Number.F2m (
 ) where
 
 import Crypto.Number.Basic
-import Data.Bits (setBit, shift, testBit, xor)
+import Data.Bits (setBit, shift, testBit, xor, unsafeShiftR)
 import Data.List
 
 -- | Binary Polynomial represented by an integer
@@ -216,10 +216,12 @@ traceF2m fx = foldr addF2m 0 . take (log2 fx) . iterate (squareF2m fx)
 {-# INLINE traceF2m #-}
 
 halfTraceF2m :: BinaryPolynomial -> Integer -> Integer
-halfTraceF2m fx = foldr addF2m 0 . take (1 + log2 fx `div` 2) . iterate (squareF2m fx . squareF2m fx)
+halfTraceF2m fx = foldr addF2m 0 . take (1 + log2 fx `unsafeShiftR` 1) . iterate (squareF2m fx . squareF2m fx)
 {-# INLINE halfTraceF2m #-}
 
 -- | Solve a quadratic equation of the form @x^2 + x = a@ in F₂m.
 quadraticF2m :: BinaryPolynomial -> Integer -> Maybe Integer
-quadraticF2m fx a = if traceF2m fx a == 0 then Just $ halfTraceF2m fx a else Nothing
+quadraticF2m fx a
+    | traceF2m fx a == 0 = Just $ halfTraceF2m fx a
+    | otherwise = Nothing
 {-# INLINABLE quadraticF2m #-}

--- a/Crypto/Number/F2m.hs
+++ b/Crypto/Number/F2m.hs
@@ -20,6 +20,7 @@ module Crypto.Number.F2m (
     sqrtF2m,
     invF2m,
     divF2m,
+    quadraticF2m,
 ) where
 
 import Crypto.Number.Basic
@@ -209,3 +210,16 @@ divF2m
     -- ^ Quotient
 divF2m fx n1 n2 = mulF2m fx n1 <$> invF2m fx n2
 {-# INLINE divF2m #-}
+
+traceF2m :: BinaryPolynomial -> Integer -> Integer
+traceF2m fx = foldr addF2m 0 . take (log2 fx) . iterate (squareF2m fx)
+{-# INLINE traceF2m #-}
+
+halfTraceF2m :: BinaryPolynomial -> Integer -> Integer
+halfTraceF2m fx = foldr addF2m 0 . take (1 + log2 fx `div` 2) . iterate (squareF2m fx . squareF2m fx)
+{-# INLINE halfTraceF2m #-}
+
+-- | Solve a quadratic equation of the form @x^2 + x = a@ in F₂m.
+quadraticF2m :: BinaryPolynomial -> Integer -> Maybe Integer
+quadraticF2m fx a = if traceF2m fx a == 0 then Just $ halfTraceF2m fx a else Nothing
+{-# INLINABLE quadraticF2m #-}

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -20,7 +20,7 @@ module Crypto.PubKey.ECC.ECDSA (
     signExtendedDigest,
     verify,
     verifyDigest,
-    recover,
+    recoverDigest,
 ) where
 
 import Control.Monad
@@ -188,9 +188,9 @@ verify
     => hash -> PublicKey -> Signature -> msg -> Bool
 verify hashAlg pk sig msg = verifyDigest pk sig (hashWith hashAlg msg)
 
--- | Recover the public key from a signature.
-recover :: HashAlgorithm hash => Curve -> Digest hash -> ExtendedSignature -> Maybe PublicKey
-recover curve digest (ExtendedSignature i p (Signature r s)) = do
+-- | Recover the public key from an extended signature and a digest.
+recoverDigest :: HashAlgorithm hash => Curve -> ExtendedSignature -> Digest hash -> Maybe PublicKey
+recoverDigest curve (ExtendedSignature i p (Signature r s)) digest = do
     let CurveCommon _ _ g n _ = common_curve curve
     let z = dsaTruncHashDigest digest n
     w <- inverse r n

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -17,6 +17,7 @@ module Crypto.PubKey.ECC.ECDSA (
     signExtendedDigestWith,
     sign,
     signDigest,
+    signExtendedDigest,
     verify,
     verifyDigest,
     recover,
@@ -134,16 +135,24 @@ signWith k pk hashAlg msg = signDigestWith k pk (hashWith hashAlg msg)
 -- | Sign digest using the private key.
 --
 -- /WARNING:/ Vulnerable to timing attacks.
-signDigest
+signExtendedDigest
     :: (HashAlgorithm hash, MonadRandom m)
-    => PrivateKey -> Digest hash -> m Signature
-signDigest pk digest = do
+    => PrivateKey -> Digest hash -> m ExtendedSignature
+signExtendedDigest pk digest = do
     k <- generateBetween 1 (n - 1)
-    case signDigestWith k pk digest of
-        Nothing -> signDigest pk digest
+    case signExtendedDigestWith k pk digest of
+        Nothing -> signExtendedDigest pk digest
         Just sig -> return sig
   where
     n = ecc_n . common_curve $ private_curve pk
+
+-- | Sign digest using the private key.
+--
+-- /WARNING:/ Vulnerable to timing attacks.
+signDigest
+    :: (HashAlgorithm hash, MonadRandom m)
+    => PrivateKey -> Digest hash -> m Signature
+signDigest pk digest = signature <$> signExtendedDigest pk digest
 
 -- | Sign message using the private key.
 --

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -45,10 +45,10 @@ data Signature = Signature
 
 -- | ECDSA signature with public key recovery information.
 data ExtendedSignature = ExtendedSignature
-    { parity :: Bool
-    -- ^ Parity of the Y coordinate: @odd y@
-    , index :: Integer
-    -- ^ Index of the X coordinate: @x `div` n@
+    { index :: Integer
+    -- ^ Index of the X coordinate
+    , parity :: Bool
+    -- ^ Parity of the Y coordinate
     , signature :: Signature
     -- ^ Inner signature
     }
@@ -99,7 +99,7 @@ signExtendedDigestWith k (PrivateKey curve d) digest = do
     kInv <- inverse k n
     let s = kInv * (z + r * d) `mod` n
     when (r == 0 || s == 0) Nothing
-    return $ ExtendedSignature p i $ Signature r s
+    return $ ExtendedSignature i p $ Signature r s
 
 -- | Sign digest using the private key and an explicit k number.
 --
@@ -181,7 +181,7 @@ verify hashAlg pk sig msg = verifyDigest pk sig (hashWith hashAlg msg)
 
 -- | Recover the public key from a signature.
 recover :: HashAlgorithm hash => Curve -> Digest hash -> ExtendedSignature -> Maybe PublicKey
-recover curve digest (ExtendedSignature p i (Signature r s)) = do
+recover curve digest (ExtendedSignature i p (Signature r s)) = do
     let CurveCommon _ _ g n _ = common_curve curve
     let z = dsaTruncHashDigest digest n
     w <- inverse r n

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -94,15 +94,11 @@ signExtendedDigestWith
 signExtendedDigestWith k (PrivateKey curve d) digest = do
     let z = dsaTruncHashDigest digest n
         CurveCommon _ _ g n _ = common_curve curve
-    let point = pointMul curve k g
-    (x, y) <- case point of
-        PointO -> Nothing
-        Point x y -> return (x, y)
-    let (i, r) = x `divMod` n
+    (i, r, p) <- pointDecompose curve $ pointMul curve k g
     kInv <- inverse k n
     let s = kInv * (z + r * d) `mod` n
     when (r == 0 || s == 0) Nothing
-    return $ ExtendedSignature (odd y) i (Signature r s)
+    return $ ExtendedSignature p i $ Signature r s
 
 -- | Sign digest using the private key and an explicit k number.
 --

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -46,8 +46,8 @@ data Signature = Signature
 data ExtendedSignature = ExtendedSignature
     { parity :: Bool
     -- ^ Parity of the Y coordinate: @odd y@
-    , offset :: Bool
-    -- ^ Offset of the X coordinate: @x /= r@
+    , index :: Integer
+    -- ^ Index of the X coordinate: @x `div` n@
     , signature :: Signature
     -- ^ Inner signature
     }
@@ -98,11 +98,11 @@ signExtendedDigestWith k (PrivateKey curve d) digest = do
     (x, y) <- case point of
         PointO -> Nothing
         Point x y -> return (x, y)
-    let r = x `mod` n
+    let (i, r) = x `divMod` n
     kInv <- inverse k n
     let s = kInv * (z + r * d) `mod` n
     when (r == 0 || s == 0) Nothing
-    return $ ExtendedSignature (odd y) (x /= r) (Signature r s)
+    return $ ExtendedSignature (odd y) i (Signature r s)
 
 -- | Sign digest using the private key and an explicit k number.
 --

--- a/Crypto/PubKey/ECC/Prim.hs
+++ b/Crypto/PubKey/ECC/Prim.hs
@@ -10,6 +10,7 @@ module Crypto.PubKey.ECC.Prim (
     pointMul,
     pointAddTwoMuls,
     pointDecompose,
+    pointCompose,
     isPointAtInfinity,
     isPointValid,
 ) where
@@ -152,6 +153,24 @@ pointDecompose curve (Point x y) = do
         CurveF2m _ | x == 0 -> pure False
         CurveF2m (CurveBinary fx _) -> odd <$> divF2m fx y x
     pure (index, residue, parity)
+
+-- | Compose a point from index, residue, and parity.
+--
+-- Adapted from SEC 1: Elliptic Curve Cryptography, Version 2.0, section 2.3.4.
+pointCompose :: Curve -> Integer -> Integer -> Bool -> Maybe Point
+pointCompose curve index residue parity = do
+    let CurveCommon a b _ n _ = common_curve curve
+    let x = residue + index * n
+    y <- case curve of
+        CurveFP (CurvePrime p _) -> do
+            z <- squareRoot p $ x ^ (3 :: Int) + a * x + b
+            pure $ if odd z == parity then z else p - z
+        CurveF2m (CurveBinary fx _) | x == 0 -> pure $ sqrtF2m fx b
+        CurveF2m (CurveBinary fx _) -> do
+            c <- divF2m fx b $ squareF2m fx x
+            z <- quadraticF2m fx $ addF2m x $ addF2m a c
+            pure $ mulF2m fx x $ if odd z == parity then z else addF2m 1 z
+    pure $ Point x y
 
 -- | Check if a point is the point at infinity.
 isPointAtInfinity :: Point -> Bool

--- a/tests/ECDSA.hs
+++ b/tests/ECDSA.hs
@@ -5,7 +5,8 @@ module ECDSA (tests) where
 
 import qualified Crypto.ECC as ECDSA
 import Crypto.Error
-import Crypto.Hash.Algorithms
+import Crypto.Hash
+import qualified Crypto.PubKey.ECC.Generate as ECC
 import qualified Crypto.PubKey.ECC.ECDSA as ECC
 import qualified Crypto.PubKey.ECC.Types as ECC
 import qualified Crypto.PubKey.ECDSA as ECDSA
@@ -43,16 +44,38 @@ sigECCToECDSA prx (ECC.Signature r s) =
         (throwCryptoError $ ECDSA.scalarFromInteger prx r)
         (throwCryptoError $ ECDSA.scalarFromInteger prx s)
 
-tests =
-    localOption (QuickCheckTests 5) $
+testRecover :: ECC.CurveName -> TestTree
+testRecover name = testProperty (show name) $ \ (ArbitraryBS0_2901 msg) -> do
+    let curve = ECC.getCurveByName name
+    let n = ECC.ecc_n $ ECC.common_curve curve
+    k <- choose (1, n - 1)
+    d <- choose (1, n - 1)
+    let key = ECC.PrivateKey curve d
+    let digest = hashWith SHA256 msg
+    let pub = ECC.signExtendedDigestWith k key digest >>= ECC.recover curve digest
+    pure $ propertyHold [eqTest "recovery" (Just $ ECC.generateQ curve d) (ECC.public_q <$> pub)]
+
+tests = testGroup "ECDSA"
+    [ localOption (QuickCheckTests 5) $
         testGroup
-            "ECDSA"
+            "verification"
             [ testProperty "SHA1" $ propertyECDSA SHA1
             , testProperty "SHA224" $ propertyECDSA SHA224
             , testProperty "SHA256" $ propertyECDSA SHA256
             , testProperty "SHA384" $ propertyECDSA SHA384
             , testProperty "SHA512" $ propertyECDSA SHA512
             ]
+    , testGroup "recovery"
+        [ localOption (QuickCheckTests 100) $ testRecover ECC.SEC_p128r1
+        , localOption (QuickCheckTests 100) $ testRecover ECC.SEC_p128r2
+        , localOption (QuickCheckTests 100) $ testRecover ECC.SEC_p256k1
+        , localOption (QuickCheckTests 100) $ testRecover ECC.SEC_p256r1
+        , localOption (QuickCheckTests 50) $ testRecover ECC.SEC_t131r1
+        , localOption (QuickCheckTests 50) $ testRecover ECC.SEC_t131r2
+        , localOption (QuickCheckTests 20) $ testRecover ECC.SEC_t233k1
+        , localOption (QuickCheckTests 20) $ testRecover ECC.SEC_t233r1
+        ]
+    ]
   where
     propertyECDSA hashAlg (Curve c curve _) (ArbitraryBS0_2901 msg) = do
         d <- arbitraryScalar curve

--- a/tests/ECDSA.hs
+++ b/tests/ECDSA.hs
@@ -52,7 +52,7 @@ testRecover name = testProperty (show name) $ \ (ArbitraryBS0_2901 msg) -> do
     d <- choose (1, n - 1)
     let key = ECC.PrivateKey curve d
     let digest = hashWith SHA256 msg
-    let pub = ECC.signExtendedDigestWith k key digest >>= ECC.recover curve digest
+    let pub = ECC.signExtendedDigestWith k key digest >>= \ signature -> ECC.recoverDigest curve signature digest
     pure $ propertyHold [eqTest "recovery" (Just $ ECC.generateQ curve d) (ECC.public_q <$> pub)]
 
 tests = testGroup "ECDSA"


### PR DESCRIPTION
This is a minimal set of changes that would fix #41 for my use case.

The primary use case for public key recovery seems to be cryptocurrencies. I have tried my best to make this as general as possible without bringing in any specifics of that use case. For example, many cryptocurrencies use `secp256k1`, where it is nearly impossible for the `offset` flag to be set, so it is often not even calculated.

I decided to go with an `ExtendedSignature` type rather than just a tuple. I also decided to represent the recovery information as two `Bool` fields rather than one numeric field consisting of two packed bits. The advantage of having two `Bool` fields are stronger types (guaranteeing exactly two bits of information), and easier manipulation of the individual bits (no bit operations like `xor` are required). This will also be useful in a potential future PR for signature normalization.

This is a draft PR for now since there are still several open questions:
1. Should I add tests? I am not sure if there are any established test suites for this, so the best I could do is calculate the recovery information with the current implementation. It would help establish correctness of the implementation, but it would at least help protect from regressions.
2. Should I add an algorithm that actually performs public key recovery (rather than just outputting the recovery information as part of the signing process). This would enable some closed-loop tests where we could test if the public key that was used can actually be recovered. However, I am not sure if I am knowledgeable enough to do this.
3. The current module contains several variations for each function (`signDigestWith`, `signWith`, `signDigest`, `sign` in decreasing order of generality). The recovery information adds one more variant. If we want to have all options, this would amount to 2³ = 8 functions in total. I can easily do this, but I do not know if it is a good idea. In an ideal world, maybe it would be better to have a small helper function that takes care of the generation of `k`, as well as requiring users to do the transformation from message into digest. However, these would be breaking changes so it seems like we are stuck with many different versions of the same function. I do not know if we should have all 8 versions or only a subset thereof.
4. Should extended signatures and public key recovery be added to the `Crypto.PubKey.ECDSA` module aswell?