### PR TITLE
ECDSA Signature Normalization

### DIFF
--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -28,6 +28,7 @@ module Crypto.PubKey.ECC.ECDSA (
 
 import Control.Monad
 import Data.Data
+import Data.Bits
 
 import Crypto.Hash
 import Crypto.Internal.ByteArray (ByteArrayAccess)
@@ -210,12 +211,12 @@ recover hashAlg curve sig msg = recoverDigest curve sig $ hashWith hashAlg msg
 
 normalize :: Curve -> Signature -> Signature
 normalize curve (Signature r s)
-    | s <= n `div` 2 = Signature r s
+    | s <= n `unsafeShiftR` 1 = Signature r s
     | otherwise = Signature r (n - s)
     where n = ecc_n $ common_curve curve
 
 normalizeExtended :: Curve -> ExtendedSignature -> ExtendedSignature
 normalizeExtended curve (ExtendedSignature i p (Signature r s))
-    | s <= n `div` 2 = ExtendedSignature i p (Signature r s)
+    | s <= n `unsafeShiftR` 1 = ExtendedSignature i p (Signature r s)
     | otherwise = ExtendedSignature i (not p) (Signature r (n - s))
     where n = ecc_n $ common_curve curve

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -209,12 +209,14 @@ recover
     => hash -> Curve -> ExtendedSignature -> msg -> Maybe PublicKey
 recover hashAlg curve sig msg = recoverDigest curve sig $ hashWith hashAlg msg
 
+-- | Normalize a signature to be in low-S form.
 normalize :: Curve -> Signature -> Signature
 normalize curve (Signature r s)
     | s <= n `unsafeShiftR` 1 = Signature r s
     | otherwise = Signature r (n - s)
     where n = ecc_n $ common_curve curve
 
+-- | Normalize an extended signature to be in low-S form.
 normalizeExtended :: Curve -> ExtendedSignature -> ExtendedSignature
 normalizeExtended curve (ExtendedSignature i p (Signature r s))
     | s <= n `unsafeShiftR` 1 = ExtendedSignature i p (Signature r s)

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -22,6 +22,8 @@ module Crypto.PubKey.ECC.ECDSA (
     verifyDigest,
     recover,
     recoverDigest,
+    normalize,
+    normalizeExtended,
 ) where
 
 import Control.Monad
@@ -205,3 +207,15 @@ recover
     :: (ByteArrayAccess msg, HashAlgorithm hash)
     => hash -> Curve -> ExtendedSignature -> msg -> Maybe PublicKey
 recover hashAlg curve sig msg = recoverDigest curve sig $ hashWith hashAlg msg
+
+normalize :: Curve -> Signature -> Signature
+normalize curve (Signature r s)
+    | s <= n `div` 2 = Signature r s
+    | otherwise = Signature r (n - s)
+    where n = ecc_n $ common_curve curve
+
+normalizeExtended :: Curve -> ExtendedSignature -> ExtendedSignature
+normalizeExtended curve (ExtendedSignature i p (Signature r s))
+    | s <= n `div` 2 = ExtendedSignature i p (Signature r s)
+    | otherwise = ExtendedSignature i (not p) (Signature r (n - s))
+    where n = ecc_n $ common_curve curve

--- a/tests/KAT_PubKey/ECDSA.hs
+++ b/tests/KAT_PubKey/ECDSA.hs
@@ -32,6 +32,13 @@ instance Show Entry where
         (show $ B.take 8 $ message entry)
         (show $ hashAlgorithm entry)
 
+normalize :: Entry -> Entry
+normalize entry
+    | s <= n `div` 2 = entry
+    | otherwise = entry { signature = Signature r (n - s) } where
+    Signature r s = signature entry
+    n = ecc_n $ common_curve $ getCurveByName $ curveName entry
+
 -- taken from GEC 2: Test Vectors for SEC 1
 gec2Entries :: [Entry]
 gec2Entries = [
@@ -874,5 +881,5 @@ testEntry entry = testGroup (show entry) tests where
 
 ecdsaTests :: TestTree
 ecdsaTests = testGroup "ECDSA" [
-    testGroup "GEC 2" $ testEntry <$> gec2Entries,
-    testGroup "RFC 6979" $ testEntry <$> flatten rfc6979Entries]
+    testGroup "GEC 2" $ testEntry . normalize <$> gec2Entries,
+    testGroup "RFC 6979" $ testEntry . normalize <$> flatten rfc6979Entries]


### PR DESCRIPTION
This PR adds ECDSA signature normalization. By canonicalizing ECDSA signatures to low-S form, the problem known as ECDSA malleability is avoided.

This approach is used in several cryptocurrencies:
- https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki
- https://scsfg.io/hackers/signature-attacks/#signature-malleability

Unlike public key recovery, the normalization function does not require any access to ECDSA internals. Thus, this function could also be implemented by users of the crypton library. If these functions are considered to be outside of the scope of crypton, it would not be a big problem to force users to implement them themselves. On the other hand, the functions are very simple and do not interfere with the other ECDSA functions in any way, so maybe it is okay to have them in crypton.