### PR TITLE
Deterministic Nonce Generation for ECDSA

### DIFF
--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -28,10 +28,9 @@ module Crypto.PubKey.ECC.ECDSA (
 import Control.Monad
 import Data.Data
 import Data.Bits
-import Data.ByteString (ByteString)
+import Data.ByteArray (ByteArrayAccess, ScrubbedBytes)
 
 import Crypto.Hash
-import Crypto.Internal.ByteArray (ByteArrayAccess)
 import Crypto.Number.Basic
 import Crypto.Number.Generate
 import Crypto.Number.Serialize
@@ -221,7 +220,7 @@ deterministicNonce
     => hashDRG -> PrivateKey -> Digest hashDigest -> (Integer -> Maybe a) -> a
 deterministicNonce alg (PrivateKey curve key) digest go = fst $ withDRG state run where
     state = update seed $ initial alg where
-        seed = i2ospOf_ bytes key <> i2ospOf_ bytes message :: ByteString
+        seed = i2ospOf_ bytes key <> i2ospOf_ bytes message :: ScrubbedBytes
         message = dsaTruncHashDigest digest n `mod` n
     run = do
         k <- generatePrefix bits

--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -226,6 +226,6 @@ deterministicNonce alg (PrivateKey curve key) digest go = fst $ withDRG state ru
     run = do
         k <- generatePrefix bits
         if 0 < k && k < n then maybe run pure $ go k else run
-    bytes = (bits + 7) `div` 8
+    bytes = (bits + 7) `unsafeShiftR` 3
     bits = numBits n
     n = ecc_n $ common_curve curve

--- a/Crypto/Random/HmacDRG.hs
+++ b/Crypto/Random/HmacDRG.hs
@@ -1,8 +1,9 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Crypto.Random.HmacDRG (HmacDRG, initial, update) where
 
 import Data.Maybe
-import qualified Data.ByteString as B
-import Data.ByteArray (ByteArrayAccess)
+import Data.ByteArray (ByteArrayAccess, Bytes, ScrubbedBytes)
 import qualified Data.ByteArray as M
 import Crypto.Hash
 import Crypto.MAC.HMAC (HMAC (..), hmac)
@@ -16,7 +17,7 @@ data HmacDRG hash = HmacDRG (Digest hash) (Digest hash)
 -- | The initial DRG state. It should be seeded via 'update' before use.
 initial :: HashAlgorithm hash => hash -> HmacDRG hash
 initial algorithm = HmacDRG (constant 0x00) (constant 0x01) where
-    constant = fromJust . digestFromByteString . B.replicate (hashDigestSize algorithm)
+    constant = fromJust . digestFromByteString . M.replicate @Bytes (hashDigestSize algorithm)
 
 -- | Update the DRG state with optional provided data.
 update :: ByteArrayAccess input => HashAlgorithm hash => input -> HmacDRG hash -> HmacDRG hash
@@ -24,13 +25,13 @@ update input state0 = if M.null input then state1 else state2 where
     state1 = step 0x00 state0
     state2 = step 0x01 state1
     step byte (HmacDRG key value) = HmacDRG keyNew valueNew where
-        keyNew = hmacGetDigest $ hmac key $ M.convert value <> B.singleton byte <> M.convert input
+        keyNew = hmacGetDigest $ hmac key $ M.convert value <> M.singleton @ScrubbedBytes byte <> M.convert input
         valueNew = hmacGetDigest $ hmac keyNew value
 
 instance HashAlgorithm hash => DRG (HmacDRG hash) where
     randomBytesGenerate count (HmacDRG key value) = (output, state) where
         output = M.take count result
-        state = update B.empty $ HmacDRG key new
+        state = update @Bytes M.empty $ HmacDRG key new
         (result, new) = go M.empty value
         go buffer current
             | M.length buffer >= count = (buffer, current)

--- a/Crypto/Random/HmacDRG.hs
+++ b/Crypto/Random/HmacDRG.hs
@@ -1,0 +1,38 @@
+module Crypto.Random.HmacDRG (HmacDRG, initial, update) where
+
+import Data.Maybe
+import qualified Data.ByteString as B
+import Data.ByteArray (ByteArrayAccess)
+import qualified Data.ByteArray as M
+import Crypto.Hash
+import Crypto.MAC.HMAC (HMAC (..), hmac)
+import Crypto.Random.Types
+
+-- | HMAC-based Deterministic Random Generator
+--
+-- Adapted from NIST Special Publication 800-90A Revision 1, Section 10.1.2
+data HmacDRG hash = HmacDRG (Digest hash) (Digest hash)
+
+-- | The initial DRG state. It should be seeded via 'update' before use.
+initial :: HashAlgorithm hash => hash -> HmacDRG hash
+initial algorithm = HmacDRG (constant 0x00) (constant 0x01) where
+    constant = fromJust . digestFromByteString . B.replicate (hashDigestSize algorithm)
+
+-- | Update the DRG state with optional provided data.
+update :: ByteArrayAccess input => HashAlgorithm hash => input -> HmacDRG hash -> HmacDRG hash
+update input state0 = if M.null input then state1 else state2 where
+    state1 = step 0x00 state0
+    state2 = step 0x01 state1
+    step byte (HmacDRG key value) = HmacDRG keyNew valueNew where
+        keyNew = hmacGetDigest $ hmac key $ M.convert value <> B.singleton byte <> M.convert input
+        valueNew = hmacGetDigest $ hmac keyNew value
+
+instance HashAlgorithm hash => DRG (HmacDRG hash) where
+    randomBytesGenerate count (HmacDRG key value) = (output, state) where
+        output = M.take count result
+        state = update B.empty $ HmacDRG key new
+        (result, new) = go M.empty value
+        go buffer current
+            | M.length buffer >= count = (buffer, current)
+            | otherwise = go (buffer <> M.convert next) next
+            where next = hmacGetDigest $ hmac key current

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -276,6 +276,7 @@ library
         Crypto.Random.Entropy.Source
         Crypto.Random.Entropy.Backend
         Crypto.Random.ChaChaDRG
+        Crypto.Random.HmacDRG
         Crypto.Random.SystemDRG
         Crypto.Random.Probabilistic
         Crypto.PubKey.Internal


### PR DESCRIPTION
This adds the main algorithm from [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979), which generates deterministic nonces for ECDSA signing from the private key and the message hash to be signed.

According to [RFC 6979 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6979#section-3.3), the nonce generation can be viewed as a result of generating bits using the `HMAC_DRBG` PRNG from [NIST.SP.800-90Ar1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf). This architecture allows for a more clean separation between the generation of random bits and the usage of those bits for generating a nonce to be used in ECDSA. Thus, I added a new `DRG` instance `HmacDRG` in `Crypto.Random.HmacDRG`.

It was important to me to implement the algorithm from RFC 6979 faithfully and to make sure that the resulting nonces are exactly the same. The RFC contains 150 test cases across 15 curves, 2 messages, and 5 hash functions (see also #44). By making sure that the results are exact, they can be compared to these test cases to gain some confidence in the correctness of the algorithm.

This requirement also meant that I could not use the `Crypto.Number.Generate.generateParams` function to generate the nonce from a properly initialized `HmacDRG`, since `generateParams` takes the bits from the wrong end of a sequence of generated bytes. Because of this, I added the function `Crypto.Number.Generate.generatePrefix`.

Finally, the function `Crypto.PubKey.ECC.ECDSA.deterministicNonce` implements the main algorithm. The description in [RFC 6979 Section 3.2](https://datatracker.ietf.org/doc/html/rfc6979#section-3.2) contains many technical details about shifting bits, and converting and truncating sequences. It turned out that existing functions like `i2ospOf_` and `dsaTruncHashDigest` implemented most of the required semantics so the final implementation is a lot shorter than the version presented in the RFC.

The function `deterministicNonce` has the following signature:
```hs
deterministicNonce
    :: (HashAlgorithm hashDRG, HashAlgorithm hashDigest)
    => hashDRG -> PrivateKey -> Digest hashDigest -> (Integer -> Maybe a) -> a
```
The idea is that the parameter with type `Integer -> Maybe a` is one of the `sign*With` functions. The algorithm will continue generating nonces until the given `sign*With` function accepts one and then pass on the result.