### PR TITLE
make sign of Ed25519 safer.

### DIFF
--- a/Crypto/PubKey/Ed25519.hs
+++ b/Crypto/PubKey/Ed25519.hs
@@ -118,7 +118,7 @@ sign secret _public message =
     !msgLen = B.length message
     public = toPublic secret
 
--- | Sign a message using the key pair.  This is old 'sing' which may
+-- | Sign a message using the key pair.  This is old 'sign' which may
 --   be vulnerable to Double Public Key Signing Function Oracle
 --   Attack.
 signUnsafe :: ByteArrayAccess ba => SecretKey -> PublicKey -> ba -> Signature

--- a/Crypto/PubKey/Ed25519.hs
+++ b/Crypto/PubKey/Ed25519.hs
@@ -130,7 +130,6 @@ signUnsafe secret public message =
                     ccrypton_ed25519_sign msg (fromIntegral msgLen) sec pub sig
   where
     !msgLen = B.length message
-{-# DEPRECATED signUnsafe "Use 'sign' instead" #-}
 
 -- | Verify a message
 verify :: ByteArrayAccess ba => PublicKey -> ba -> Signature -> Bool

--- a/Crypto/PubKey/Ed25519.hs
+++ b/Crypto/PubKey/Ed25519.hs
@@ -27,11 +27,9 @@ module Crypto.PubKey.Ed25519 (
     -- * Methods
     toPublic,
     sign,
+    unsafeSign,
     verify,
     generateSecretKey,
-
-    -- * deprecated
-    unsafeSign,
 ) where
 
 import Data.Word

--- a/Crypto/PubKey/Ed25519.hs
+++ b/Crypto/PubKey/Ed25519.hs
@@ -118,9 +118,11 @@ sign secret _public message =
     !msgLen = B.length message
     public = toPublic secret
 
--- | Sign a message using the key pair.  This is old 'sign' which may
---   be vulnerable to Double Public Key Signing Function Oracle
---   Attack.
+-- | Sign a message using the key pair.  This is old `sign`, which is
+-- vulnerable to private key compromise if the given public key does
+-- not correspond to the secret key. This function is provided for
+-- performance critical applications. To use it safely, applications
+-- must verify or derive the public key.
 signUnsafe :: ByteArrayAccess ba => SecretKey -> PublicKey -> ba -> Signature
 signUnsafe secret public message =
     Signature $ B.allocAndFreeze signatureSize $ \sig ->

--- a/Crypto/PubKey/Ed25519.hs
+++ b/Crypto/PubKey/Ed25519.hs
@@ -31,7 +31,7 @@ module Crypto.PubKey.Ed25519 (
     generateSecretKey,
 
     -- * deprecated
-    signUnsafe,
+    unsafeSign,
 ) where
 
 import Data.Word
@@ -123,8 +123,8 @@ sign secret _public message =
 -- not correspond to the secret key. This function is provided for
 -- performance critical applications. To use it safely, applications
 -- must verify or derive the public key.
-signUnsafe :: ByteArrayAccess ba => SecretKey -> PublicKey -> ba -> Signature
-signUnsafe secret public message =
+unsafeSign :: ByteArrayAccess ba => SecretKey -> PublicKey -> ba -> Signature
+unsafeSign secret public message =
     Signature $ B.allocAndFreeze signatureSize $ \sig ->
         withByteArray secret $ \sec ->
             withByteArray public $ \pub ->


### PR DESCRIPTION
This should prevent Double Public Key Signing Function Oracle Attack.