### PR TITLE
Ed448.sign: avoid extra re-derive of public key

### DIFF
--- a/cbits/decaf/ed448goldilocks/eddsa.c
+++ b/cbits/decaf/ed448goldilocks/eddsa.c
@@ -233,12 +233,14 @@ void crypton_decaf_ed448_sign (
     const uint8_t *context,
     uint8_t context_len
 ) {
+    /* rederivation already performed in Crypto.PubKey.Ed448.sign
     uint8_t rederived_pubkey[CRYPTON_DECAF_EDDSA_448_PUBLIC_BYTES];
     crypton_decaf_ed448_derive_public_key(rederived_pubkey, privkey);
     if (CRYPTON_DECAF_TRUE != crypton_decaf_memeq(rederived_pubkey, pubkey, sizeof(rederived_pubkey))) {
         abort();
     }
-    crypton_decaf_ed448_sign_internal(signature,privkey,rederived_pubkey,message,
+    */
+    crypton_decaf_ed448_sign_internal(signature,privkey,/*rederived_*/pubkey,message,
         message_len,prehashed,context,context_len);
 }
 


### PR DESCRIPTION
Commit f54507e1f3c848748300cec0f400361afb464cc9 updated the ed448 Haskell code to unconditionally re-derive the public key (to avoid private key oracle attacks when public key does not correspond to private key).  This change in Ed448 followed corresponding changes to Ed25519.  However, the Ed448 cbits (unlike the Ed25519 cbits) already unconditionally re-derived the public key (and compared it to the given key, calling `abort()` on mismatch).

As a consequence, the Ed448 `sign` function now re-derives the public key two times.  `unsafeSign`, which is provided for performance-critical use cases, also re-derives the public key, nullifying the performance advantage.

Now that `sign` re-derives the key on the Haskell side, update the Ed448 cbits to avoid re-deriving the public key there.  This is achieved by commenting out the lines that perform the re-derivation.

**Note:** the commit message describing the change incorrectly refers to an abandoned approach.  The erroneous text is:

> This is achieved by removing the current implementation of `crypton_decaf_ed448_sign()` and replacing it by renaming `crypton_decaf_ed448_sign_internal()`.