### PR TITLE
build(cabal): haskell-language-server to work

### DIFF
--- a/crypton.cabal
+++ b/crypton.cabal
@@ -520,3 +520,5 @@ benchmark bench-crypton
         gauge,
         random,
         crypton
+
+-- cabal-fmt: indent 4

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -121,6 +121,7 @@ flag use_target_attributes
     manual:      True
 
 library
+    -- cabal-fmt: expand . -CHANGELOG -CONTRIBUTING -Crypto.Math.Polynomial -Crypto.Random.Entropy.RDRand -Crypto.Random.Entropy.Unix -Crypto.Random.Entropy.Windows -LICENSE -Makefile -QA -README -Setup -Crypto.Cipher.Blowfish.Box -Crypto.Cipher.Blowfish.Primitive -Crypto.Cipher.CAST5.Primitive -Crypto.Cipher.Camellia.Primitive -Crypto.Cipher.DES.Primitive -Crypto.Cipher.Twofish.Primitive -Crypto.Cipher.Types.AEAD -Crypto.Cipher.Types.Base -Crypto.Cipher.Types.Block -Crypto.Cipher.Types.GF -Crypto.Cipher.Types.Stream -Crypto.Cipher.Types.Utils -Crypto.ECC.Simple.Prim -Crypto.ECC.Simple.Types -Crypto.Error.Types -Crypto.Hash.Blake2 -Crypto.Hash.Blake2b -Crypto.Hash.Blake2bp -Crypto.Hash.Blake2s -Crypto.Hash.Blake2sp -Crypto.Hash.Keccak -Crypto.Hash.MD2 -Crypto.Hash.MD4 -Crypto.Hash.MD5 -Crypto.Hash.RIPEMD160 -Crypto.Hash.SHA1 -Crypto.Hash.SHA224 -Crypto.Hash.SHA256 -Crypto.Hash.SHA3 -Crypto.Hash.SHA384 -Crypto.Hash.SHA512 -Crypto.Hash.SHA512t -Crypto.Hash.SHAKE -Crypto.Hash.Skein256 -Crypto.Hash.Skein512 -Crypto.Hash.Tiger -Crypto.Hash.Types -Crypto.Hash.Whirlpool -Crypto.Internal.Builder -Crypto.Internal.ByteArray -Crypto.Internal.Compat -Crypto.Internal.CompatPrim -Crypto.Internal.DeepSeq -Crypto.Internal.Endian -Crypto.Internal.Imports -Crypto.Internal.Nat -Crypto.Internal.WordArray -Crypto.Internal.Words -Crypto.Number.Compat -Crypto.PubKey.ElGamal -Crypto.PubKey.Internal -Crypto.Random.ChaChaDRG -Crypto.Random.Entropy.Backend -Crypto.Random.Entropy.Source -Crypto.Random.HmacDRG -Crypto.Random.Probabilistic -Crypto.Random.SystemDRG -Crypto.Cipher.AES.Primitive
     exposed-modules:
         Crypto.Cipher.AES
         Crypto.Cipher.AESGCMSIV
@@ -203,37 +204,6 @@ library
         Crypto.System.CPU
         Crypto.Tutorial
 
-    cc-options:       -std=gnu99
-    c-sources:
-        cbits/argon2/argon2.c
-        cbits/crypton_blake2b.c
-        cbits/crypton_blake2bp.c
-        cbits/crypton_blake2s.c
-        cbits/crypton_blake2sp.c
-        cbits/crypton_chacha.c
-        cbits/crypton_cpu.c
-        cbits/crypton_md2.c
-        cbits/crypton_md4.c
-        cbits/crypton_md5.c
-        cbits/crypton_pbkdf2.c
-        cbits/crypton_poly1305.c
-        cbits/crypton_rc4.c
-        cbits/crypton_ripemd.c
-        cbits/crypton_salsa.c
-        cbits/crypton_scrypt.c
-        cbits/crypton_sha1.c
-        cbits/crypton_sha256.c
-        cbits/crypton_sha3.c
-        cbits/crypton_sha512.c
-        cbits/crypton_skein256.c
-        cbits/crypton_skein512.c
-        cbits/crypton_tiger.c
-        cbits/crypton_whirlpool.c
-        cbits/crypton_xsalsa.c
-        cbits/ed25519/ed25519.c
-        cbits/p256/p256.c
-        cbits/p256/p256_ec.c
-
     other-modules:
         Crypto.Cipher.AES.Primitive
         Crypto.Cipher.Blowfish.Box
@@ -279,6 +249,7 @@ library
         Crypto.Internal.Compat
         Crypto.Internal.CompatPrim
         Crypto.Internal.DeepSeq
+        Crypto.Internal.Endian
         Crypto.Internal.Imports
         Crypto.Internal.Nat
         Crypto.Internal.WordArray
@@ -292,6 +263,37 @@ library
         Crypto.Random.HmacDRG
         Crypto.Random.Probabilistic
         Crypto.Random.SystemDRG
+
+    cc-options:       -std=gnu99
+    c-sources:
+        cbits/argon2/argon2.c
+        cbits/crypton_blake2b.c
+        cbits/crypton_blake2bp.c
+        cbits/crypton_blake2s.c
+        cbits/crypton_blake2sp.c
+        cbits/crypton_chacha.c
+        cbits/crypton_cpu.c
+        cbits/crypton_md2.c
+        cbits/crypton_md4.c
+        cbits/crypton_md5.c
+        cbits/crypton_pbkdf2.c
+        cbits/crypton_poly1305.c
+        cbits/crypton_rc4.c
+        cbits/crypton_ripemd.c
+        cbits/crypton_salsa.c
+        cbits/crypton_scrypt.c
+        cbits/crypton_sha1.c
+        cbits/crypton_sha256.c
+        cbits/crypton_sha3.c
+        cbits/crypton_sha512.c
+        cbits/crypton_skein256.c
+        cbits/crypton_skein512.c
+        cbits/crypton_tiger.c
+        cbits/crypton_whirlpool.c
+        cbits/crypton_xsalsa.c
+        cbits/ed25519/ed25519.c
+        cbits/p256/p256.c
+        cbits/p256/p256_ec.c
 
     default-language: Haskell2010
     include-dirs:
@@ -432,6 +434,8 @@ test-suite test-crypton
     type:             exitcode-stdio-1.0
     main-is:          Tests.hs
     hs-source-dirs:   tests
+
+    -- cabal-fmt: expand tests -Tests
     other-modules:
         BCrypt
         BCryptPBKDF

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -7,7 +7,7 @@ copyright:          Vincent Hanquez <vincent@snarc.org>
 maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>
 author:             Vincent Hanquez <vincent@snarc.org>
 stability:          experimental
-tested-with:        ghc ==9.2.2 ghc ==9.0.2 ghc ==8.10.7 ghc ==8.8.4
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.2
 homepage:           https://github.com/kazu-yamamoto/crypton
 bug-reports:        https://github.com/kazu-yamamoto/crypton/issues
 synopsis:           Cryptography Primitives sink
@@ -41,29 +41,29 @@ build-type:         Simple
 extra-source-files:
     cbits/*.h
     cbits/aes/*.h
-    cbits/ed25519/*.h
-    cbits/decaf/include/*.h
-    cbits/decaf/include/decaf/*.h
-    cbits/decaf/include/arch_32/*.h
-    cbits/decaf/include/arch_ref64/*.h
-    cbits/decaf/p448/arch_32/*.h
-    cbits/decaf/p448/arch_ref64/*.h
-    cbits/decaf/p448/*.h
-    cbits/decaf/ed448goldilocks/decaf_tables.c
-    cbits/decaf/ed448goldilocks/decaf.c
-    cbits/include32/p256/*.h
-    cbits/include64/p256/*.h
+    cbits/aes/x86ni_impl.c
+    cbits/argon2/*.c
+    cbits/argon2/*.h
     cbits/blake2/ref/*.h
     cbits/blake2/sse/*.h
-    cbits/argon2/*.h
-    cbits/argon2/*.c
-    cbits/aes/x86ni_impl.c
     cbits/crypton_hash_prefix.c
+    cbits/decaf/ed448goldilocks/decaf.c
+    cbits/decaf/ed448goldilocks/decaf_tables.c
+    cbits/decaf/include/*.h
+    cbits/decaf/include/arch_32/*.h
+    cbits/decaf/include/arch_ref64/*.h
+    cbits/decaf/include/decaf/*.h
+    cbits/decaf/p448/*.h
+    cbits/decaf/p448/arch_32/*.h
+    cbits/decaf/p448/arch_ref64/*.h
+    cbits/ed25519/*.h
+    cbits/include32/p256/*.h
+    cbits/include64/p256/*.h
     tests/*.hs
 
 extra-doc-files:
-    README.md
     CHANGELOG.md
+    README.md
 
 source-repository head
     type:     git
@@ -125,8 +125,8 @@ library
         Crypto.Cipher.AES
         Crypto.Cipher.AESGCMSIV
         Crypto.Cipher.Blowfish
-        Crypto.Cipher.CAST5
         Crypto.Cipher.Camellia
+        Crypto.Cipher.CAST5
         Crypto.Cipher.ChaCha
         Crypto.Cipher.ChaChaPoly1305
         Crypto.Cipher.DES
@@ -143,11 +143,20 @@ library
         Crypto.ECC
         Crypto.ECC.Edwards25519
         Crypto.Error
+        Crypto.Hash
+        Crypto.Hash.Algorithms
+        Crypto.Hash.IO
+        Crypto.KDF.Argon2
+        Crypto.KDF.BCrypt
+        Crypto.KDF.BCryptPBKDF
+        Crypto.KDF.HKDF
+        Crypto.KDF.PBKDF2
+        Crypto.KDF.Scrypt
         Crypto.MAC.CMAC
-        Crypto.MAC.Poly1305
         Crypto.MAC.HMAC
         Crypto.MAC.KeyedBlake2
         Crypto.MAC.KMAC
+        Crypto.MAC.Poly1305
         Crypto.Number.Basic
         Crypto.Number.F2m
         Crypto.Number.Generate
@@ -155,91 +164,82 @@ library
         Crypto.Number.Nat
         Crypto.Number.Prime
         Crypto.Number.Serialize
-        Crypto.Number.Serialize.LE
         Crypto.Number.Serialize.Internal
         Crypto.Number.Serialize.Internal.LE
-        Crypto.KDF.Argon2
-        Crypto.KDF.PBKDF2
-        Crypto.KDF.Scrypt
-        Crypto.KDF.BCrypt
-        Crypto.KDF.BCryptPBKDF
-        Crypto.KDF.HKDF
-        Crypto.Hash
-        Crypto.Hash.IO
-        Crypto.Hash.Algorithms
+        Crypto.Number.Serialize.LE
         Crypto.OTP
         Crypto.PubKey.Curve25519
         Crypto.PubKey.Curve448
-        Crypto.PubKey.MaskGenFunction
         Crypto.PubKey.DH
         Crypto.PubKey.DSA
-        Crypto.PubKey.ECC.Generate
-        Crypto.PubKey.ECC.Prim
         Crypto.PubKey.ECC.DH
         Crypto.PubKey.ECC.ECDSA
+        Crypto.PubKey.ECC.Generate
         Crypto.PubKey.ECC.P256
+        Crypto.PubKey.ECC.Prim
         Crypto.PubKey.ECC.Types
         Crypto.PubKey.ECDSA
         Crypto.PubKey.ECIES
         Crypto.PubKey.Ed25519
         Crypto.PubKey.Ed448
         Crypto.PubKey.EdDSA
+        Crypto.PubKey.MaskGenFunction
+        Crypto.PubKey.Rabin.Basic
+        Crypto.PubKey.Rabin.Modified
+        Crypto.PubKey.Rabin.OAEP
+        Crypto.PubKey.Rabin.RW
+        Crypto.PubKey.Rabin.Types
         Crypto.PubKey.RSA
+        Crypto.PubKey.RSA.OAEP
         Crypto.PubKey.RSA.PKCS15
         Crypto.PubKey.RSA.Prim
         Crypto.PubKey.RSA.PSS
-        Crypto.PubKey.RSA.OAEP
         Crypto.PubKey.RSA.Types
-        Crypto.PubKey.Rabin.OAEP
-        Crypto.PubKey.Rabin.Basic
-        Crypto.PubKey.Rabin.Modified
-        Crypto.PubKey.Rabin.RW
-        Crypto.PubKey.Rabin.Types
         Crypto.Random
-        Crypto.Random.Types
         Crypto.Random.Entropy
-        Crypto.Random.EntropyPool
         Crypto.Random.Entropy.Unsafe
+        Crypto.Random.EntropyPool
+        Crypto.Random.Types
         Crypto.System.CPU
         Crypto.Tutorial
 
     cc-options:       -std=gnu99
     c-sources:
-        cbits/crypton_chacha.c
-        cbits/crypton_salsa.c
-        cbits/crypton_xsalsa.c
-        cbits/crypton_rc4.c
-        cbits/crypton_cpu.c
-        cbits/p256/p256.c
-        cbits/p256/p256_ec.c
-        cbits/crypton_blake2s.c
-        cbits/crypton_blake2sp.c
+        cbits/argon2/argon2.c
         cbits/crypton_blake2b.c
         cbits/crypton_blake2bp.c
-        cbits/crypton_poly1305.c
-        cbits/crypton_sha1.c
-        cbits/crypton_sha256.c
-        cbits/crypton_sha512.c
-        cbits/crypton_sha3.c
+        cbits/crypton_blake2s.c
+        cbits/crypton_blake2sp.c
+        cbits/crypton_chacha.c
+        cbits/crypton_cpu.c
         cbits/crypton_md2.c
         cbits/crypton_md4.c
         cbits/crypton_md5.c
+        cbits/crypton_pbkdf2.c
+        cbits/crypton_poly1305.c
+        cbits/crypton_rc4.c
         cbits/crypton_ripemd.c
+        cbits/crypton_salsa.c
+        cbits/crypton_scrypt.c
+        cbits/crypton_sha1.c
+        cbits/crypton_sha256.c
+        cbits/crypton_sha3.c
+        cbits/crypton_sha512.c
         cbits/crypton_skein256.c
         cbits/crypton_skein512.c
         cbits/crypton_tiger.c
         cbits/crypton_whirlpool.c
-        cbits/crypton_scrypt.c
-        cbits/crypton_pbkdf2.c
+        cbits/crypton_xsalsa.c
         cbits/ed25519/ed25519.c
-        cbits/argon2/argon2.c
+        cbits/p256/p256.c
+        cbits/p256/p256_ec.c
 
     other-modules:
         Crypto.Cipher.AES.Primitive
         Crypto.Cipher.Blowfish.Box
         Crypto.Cipher.Blowfish.Primitive
-        Crypto.Cipher.CAST5.Primitive
         Crypto.Cipher.Camellia.Primitive
+        Crypto.Cipher.CAST5.Primitive
         Crypto.Cipher.DES.Primitive
         Crypto.Cipher.Twofish.Primitive
         Crypto.Cipher.Types.AEAD
@@ -248,41 +248,32 @@ library
         Crypto.Cipher.Types.GF
         Crypto.Cipher.Types.Stream
         Crypto.Cipher.Types.Utils
+        Crypto.ECC.Simple.Prim
+        Crypto.ECC.Simple.Types
         Crypto.Error.Types
-        Crypto.Number.Compat
-        Crypto.Hash.Types
         Crypto.Hash.Blake2
-        Crypto.Hash.Blake2s
-        Crypto.Hash.Blake2sp
         Crypto.Hash.Blake2b
         Crypto.Hash.Blake2bp
-        Crypto.Hash.SHA1
-        Crypto.Hash.SHA224
-        Crypto.Hash.SHA256
-        Crypto.Hash.SHA384
-        Crypto.Hash.SHA512
-        Crypto.Hash.SHA512t
-        Crypto.Hash.SHA3
-        Crypto.Hash.SHAKE
+        Crypto.Hash.Blake2s
+        Crypto.Hash.Blake2sp
         Crypto.Hash.Keccak
         Crypto.Hash.MD2
         Crypto.Hash.MD4
         Crypto.Hash.MD5
         Crypto.Hash.RIPEMD160
+        Crypto.Hash.SHA1
+        Crypto.Hash.SHA224
+        Crypto.Hash.SHA256
+        Crypto.Hash.SHA3
+        Crypto.Hash.SHA384
+        Crypto.Hash.SHA512
+        Crypto.Hash.SHA512t
+        Crypto.Hash.SHAKE
         Crypto.Hash.Skein256
         Crypto.Hash.Skein512
         Crypto.Hash.Tiger
+        Crypto.Hash.Types
         Crypto.Hash.Whirlpool
-        Crypto.Random.Entropy.Source
-        Crypto.Random.Entropy.Backend
-        Crypto.Random.ChaChaDRG
-        Crypto.Random.HmacDRG
-        Crypto.Random.SystemDRG
-        Crypto.Random.Probabilistic
-        Crypto.PubKey.Internal
-        Crypto.PubKey.ElGamal
-        Crypto.ECC.Simple.Types
-        Crypto.ECC.Simple.Prim
         Crypto.Internal.Builder
         Crypto.Internal.ByteArray
         Crypto.Internal.Compat
@@ -290,8 +281,17 @@ library
         Crypto.Internal.DeepSeq
         Crypto.Internal.Imports
         Crypto.Internal.Nat
-        Crypto.Internal.Words
         Crypto.Internal.WordArray
+        Crypto.Internal.Words
+        Crypto.Number.Compat
+        Crypto.PubKey.ElGamal
+        Crypto.PubKey.Internal
+        Crypto.Random.ChaChaDRG
+        Crypto.Random.Entropy.Backend
+        Crypto.Random.Entropy.Source
+        Crypto.Random.HmacDRG
+        Crypto.Random.Probabilistic
+        Crypto.Random.SystemDRG
 
     default-language: Haskell2010
     include-dirs:
@@ -300,11 +300,11 @@ library
 
     ghc-options:      -Wall -fwarn-tabs -optc-O3
     build-depends:
-        base >=4.13 && <5,
-        bytestring,
-        memory >=0.14.18,
-        basement >=0.0.6,
-        ghc-prim
+          base        >=4.13    && <5
+        , basement    >=0.0.6
+        , bytestring
+        , ghc-prim
+        , memory      >=0.14.18
 
     if flag(old_toolchain_inliner)
         cc-options: -fgnu89-inline
@@ -317,25 +317,25 @@ library
 
     if (arch(x86_64) || arch(aarch64))
         c-sources:
-            cbits/decaf/p448/arch_ref64/f_impl.c
-            cbits/decaf/p448/f_generic.c
-            cbits/decaf/p448/f_arithmetic.c
-            cbits/decaf/utils.c
-            cbits/decaf/ed448goldilocks/scalar.c
             cbits/decaf/ed448goldilocks/decaf_all.c
             cbits/decaf/ed448goldilocks/eddsa.c
+            cbits/decaf/ed448goldilocks/scalar.c
+            cbits/decaf/p448/arch_ref64/f_impl.c
+            cbits/decaf/p448/f_arithmetic.c
+            cbits/decaf/p448/f_generic.c
+            cbits/decaf/utils.c
 
         include-dirs: cbits/decaf/include/arch_ref64 cbits/decaf/p448/arch_ref64
 
     else
         c-sources:
-            cbits/decaf/p448/arch_32/f_impl.c
-            cbits/decaf/p448/f_generic.c
-            cbits/decaf/p448/f_arithmetic.c
-            cbits/decaf/utils.c
-            cbits/decaf/ed448goldilocks/scalar.c
             cbits/decaf/ed448goldilocks/decaf_all.c
             cbits/decaf/ed448goldilocks/eddsa.c
+            cbits/decaf/ed448goldilocks/scalar.c
+            cbits/decaf/p448/arch_32/f_impl.c
+            cbits/decaf/p448/f_arithmetic.c
+            cbits/decaf/p448/f_generic.c
+            cbits/decaf/utils.c
 
         include-dirs: cbits/decaf/include/arch_32 cbits/decaf/p448/arch_32
 
@@ -362,9 +362,9 @@ library
     if ((flag(support_aesni) && ((os(linux) || os(freebsd)) || os(osx))) && (arch(i386) || arch(x86_64)))
         cc-options: -DWITH_AESNI
         c-sources:
-            cbits/aes/x86ni.c
             cbits/aes/generic.c
             cbits/aes/gf.c
+            cbits/aes/x86ni.c
             cbits/crypton_aes.c
 
         if !flag(use_target_attributes)
@@ -384,19 +384,19 @@ library
 
     if (arch(x86_64) || flag(support_sse))
         c-sources:
-            cbits/blake2/sse/blake2s.c
-            cbits/blake2/sse/blake2sp.c
             cbits/blake2/sse/blake2b.c
             cbits/blake2/sse/blake2bp.c
+            cbits/blake2/sse/blake2s.c
+            cbits/blake2/sse/blake2sp.c
 
         include-dirs: cbits/blake2/sse
 
     else
         c-sources:
-            cbits/blake2/ref/blake2s-ref.c
-            cbits/blake2/ref/blake2sp-ref.c
             cbits/blake2/ref/blake2b-ref.c
             cbits/blake2/ref/blake2bp-ref.c
+            cbits/blake2/ref/blake2s-ref.c
+            cbits/blake2/ref/blake2sp-ref.c
 
         include-dirs: cbits/blake2/ref
 
@@ -415,7 +415,7 @@ library
     else
         other-modules: Crypto.Random.Entropy.Unix
 
-    if (impl(ghc >=0) && flag(integer-gmp))
+    if (impl(ghc) && flag(integer-gmp))
         build-depends: integer-gmp
 
     if flag(support_deepseq)
@@ -433,56 +433,56 @@ test-suite test-crypton
     main-is:          Tests.hs
     hs-source-dirs:   tests
     other-modules:
-        BlockCipher
-        ChaCha
         BCrypt
         BCryptPBKDF
+        BlockCipher
+        ChaCha
+        ChaChaPoly1305
         ECC
         ECC.Edwards25519
         ECDSA
         Hash
         Imports
+        KAT_AES
         KAT_AES.KATCBC
+        KAT_AES.KATCCM
         KAT_AES.KATECB
         KAT_AES.KATGCM
-        KAT_AES.KATCCM
         KAT_AES.KATOCB3
         KAT_AES.KATXTS
-        KAT_AES
         KAT_AESGCMSIV
         KAT_AFIS
         KAT_Argon2
+        KAT_Blake2
         KAT_Blowfish
-        KAT_CAST5
         KAT_Camellia
+        KAT_CAST5
+        KAT_CMAC
         KAT_Curve25519
         KAT_Curve448
         KAT_DES
         KAT_Ed25519
         KAT_Ed448
         KAT_EdDSA
-        KAT_Blake2
-        KAT_CMAC
         KAT_HKDF
         KAT_HMAC
         KAT_KMAC
         KAT_MiyaguchiPreneel
-        KAT_PBKDF2
         KAT_OTP
+        KAT_PBKDF2
+        KAT_PubKey
         KAT_PubKey.DSA
         KAT_PubKey.ECC
         KAT_PubKey.ECDSA
         KAT_PubKey.OAEP
-        KAT_PubKey.PSS
         KAT_PubKey.P256
-        KAT_PubKey.RSA
+        KAT_PubKey.PSS
         KAT_PubKey.Rabin
-        KAT_PubKey
+        KAT_PubKey.RSA
         KAT_RC4
         KAT_Scrypt
         KAT_TripleDES
         KAT_Twofish
-        ChaChaPoly1305
         Number
         Number.F2m
         Padding
@@ -496,14 +496,14 @@ test-suite test-crypton
         -Wall -fno-warn-orphans -fno-warn-missing-signatures -rtsopts
 
     build-depends:
-        base >=4.13 && <5,
-        bytestring,
-        memory,
-        tasty,
-        tasty-quickcheck,
-        tasty-hunit,
-        tasty-kat,
-        crypton
+          base              >=4.13 && <5
+        , bytestring
+        , crypton
+        , memory
+        , tasty
+        , tasty-hunit
+        , tasty-kat
+        , tasty-quickcheck
 
 benchmark bench-crypton
     type:             exitcode-stdio-1.0
@@ -513,12 +513,12 @@ benchmark bench-crypton
     default-language: Haskell2010
     ghc-options:      -Wall -fno-warn-missing-signatures
     build-depends:
-        base >=4.13 && <5,
-        bytestring,
-        deepseq,
-        memory,
-        gauge,
-        random,
-        crypton
+          base        >=4.13 && <5
+        , bytestring
+        , crypton
+        , deepseq
+        , gauge
+        , memory
+        , random
 
 -- cabal-fmt: indent 4


### PR DESCRIPTION
The haskell-language-server wasn't working properly due to missing or extra modules specified in the cabal file, so I fixed it to at least work on my local Linux environment for now.