### PR TITLE
Add simple interface to generate full blocks

### DIFF
--- a/cbits/crypton_chacha.h
+++ b/cbits/crypton_chacha.h
@@ -51,5 +51,8 @@ void crypton_chacha_init(crypton_chacha_context *ctx, uint8_t nb_rounds, uint32_
 void crypton_xchacha_init(crypton_chacha_context *ctx, uint8_t nb_rounds, const uint8_t *key, const uint8_t *iv);
 void crypton_chacha_combine(uint8_t *dst, crypton_chacha_context *st, const uint8_t *src, uint32_t bytes);
 void crypton_chacha_generate(uint8_t *dst, crypton_chacha_context *st, uint32_t bytes);
+uint64_t crypton_chacha_counter(crypton_chacha_state *st);
+void crypton_chacha_set_counter(crypton_chacha_state *st, uint64_t block_counter);
+void crypton_chacha_generate_simple_block(uint8_t *dst, crypton_chacha_state *st, uint8_t rounds);
 
 #endif


### PR DESCRIPTION
Allow for recording of a cursor and seeking of the simple interface.

This is useful for creating predictable keyed randomness. By getting a block at a time, the number of FFI calls is minimized.