### PR TITLE
Avoid `ghc-prim` dependency

### DIFF
--- a/Crypto/Internal/CompatPrim.hs
+++ b/Crypto/Internal/CompatPrim.hs
@@ -28,9 +28,9 @@ import Data.Memory.Endian (getSystemEndianness, Endianness(..))
 #endif
 
 #if __GLASGOW_HASKELL__ >= 902
-import GHC.Prim
+import GHC.Exts
 #else
-import GHC.Prim hiding (Word32#)
+import GHC.Exts hiding (Word32#)
 type Word32# = Word#
 #endif
 

--- a/Crypto/Internal/WordArray.hs
+++ b/Crypto/Internal/WordArray.hs
@@ -38,8 +38,7 @@ import Crypto.Internal.Compat
 import Crypto.Internal.CompatPrim
 import Data.Bits (xor)
 import Data.Word
-import GHC.Prim
-import GHC.Types
+import GHC.Base
 import GHC.Word
 
 -- | Array of Word8

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -305,7 +305,6 @@ library
           base        >=4.13    && <5
         , basement    >=0.0.6
         , bytestring
-        , ghc-prim
         , memory      >=0.14.18
 
     if flag(old_toolchain_inliner)


### PR DESCRIPTION
It is not recommended to depend on `ghc-prim`. The needed primitives are also exposed from `base`.