### PR TITLE
Chacha counter

### DIFF
--- a/Crypto/Cipher/ChaCha.hs
+++ b/Crypto/Cipher/ChaCha.hs
@@ -232,15 +232,15 @@ generateSimpleBlock nbRounds (StateSimple prevSt)
                 ccrypton_chacha_generate_simple_block dstPtr stPtr nbRounds
         return (output, StateSimple newSt)
 
-foreign import ccall "crypton_chacha_init_core"
+foreign import ccall unsafe "crypton_chacha_init_core"
     ccrypton_chacha_init_core
         :: Ptr StateSimple -> Int -> Ptr Word8 -> Int -> Ptr Word8 -> IO ()
 
-foreign import ccall "crypton_chacha_init"
+foreign import ccall unsafe "crypton_chacha_init"
     ccrypton_chacha_init
         :: Ptr State -> Int -> Int -> Ptr Word8 -> Int -> Ptr Word8 -> IO ()
 
-foreign import ccall "crypton_xchacha_init"
+foreign import ccall unsafe "crypton_xchacha_init"
     ccrypton_xchacha_init :: Ptr State -> Int -> Ptr Word8 -> Ptr Word8 -> IO ()
 
 foreign import ccall "crypton_chacha_combine"
@@ -252,19 +252,19 @@ foreign import ccall "crypton_chacha_generate"
 foreign import ccall "crypton_chacha_random"
     ccrypton_chacha_random :: Int -> Ptr Word8 -> Ptr StateSimple -> CUInt -> IO ()
 
-foreign import ccall "crypton_chacha_counter64"
+foreign import ccall unsafe "crypton_chacha_counter64"
     ccrypton_chacha_counter64 :: Ptr StateSimple -> IO Word64
 
-foreign import ccall "crypton_chacha_set_counter64"
+foreign import ccall unsafe "crypton_chacha_set_counter64"
     ccrypton_chacha_set_counter64 :: Ptr StateSimple -> Word64 -> IO ()
 
-foreign import ccall "crypton_chacha_counter32"
+foreign import ccall unsafe "crypton_chacha_counter32"
     ccrypton_chacha_counter32 :: Ptr StateSimple -> IO Word32
 
-foreign import ccall "crypton_chacha_set_counter32"
+foreign import ccall unsafe "crypton_chacha_set_counter32"
     ccrypton_chacha_set_counter32 :: Ptr StateSimple -> Word32 -> IO ()
 
-foreign import ccall "crypton_chacha_generate_simple_block"
+foreign import ccall unsafe "crypton_chacha_generate_simple_block"
     ccrypton_chacha_generate_simple_block
         :: Ptr Word8 -> Ptr StateSimple -> Word8 -> IO ()
 

--- a/Crypto/Cipher/ChaCha.hs
+++ b/Crypto/Cipher/ChaCha.hs
@@ -51,16 +51,16 @@ class ChaChaState a where
     setCounter32 :: Word32 -> a -> a
 
 instance ChaChaState State where
-    getCounter64 = \(State st) -> getCounter64' st ccrypton_chacha_get_state
-    setCounter64 = \n (State st) -> State $ setCounter64' n st ccrypton_chacha_get_state
-    getCounter32 = \(State st) -> getCounter32' st ccrypton_chacha_get_state
-    setCounter32 = \n (State st) -> State $ setCounter32' n st ccrypton_chacha_get_state
+    getCounter64 (State st) = getCounter64' st ccrypton_chacha_get_state
+    setCounter64 n (State st) = State $ setCounter64' n st ccrypton_chacha_get_state
+    getCounter32 (State st) = getCounter32' st ccrypton_chacha_get_state
+    setCounter32 n (State st) = State $ setCounter32' n st ccrypton_chacha_get_state
 
 instance ChaChaState StateSimple where
-    getCounter64 = \(StateSimple st) -> getCounter64' st id
-    setCounter64 = \n (StateSimple st) -> StateSimple $ setCounter64' n st id
-    getCounter32 = \(StateSimple st) -> getCounter32' st id
-    setCounter32 = \n (StateSimple st) -> StateSimple $ setCounter32' n st id
+    getCounter64 (StateSimple st) = getCounter64' st id
+    setCounter64 n (StateSimple st) = StateSimple $ setCounter64' n st id
+    getCounter32 (StateSimple st) = getCounter32' st id
+    setCounter32 n (StateSimple st) = StateSimple $ setCounter32' n st id
 
 getCounter64' :: ScrubbedBytes -> (Ptr a -> Ptr StateSimple) -> Word64
 getCounter64' currSt conv =

--- a/Crypto/Cipher/ChaCha.hs
+++ b/Crypto/Cipher/ChaCha.hs
@@ -44,28 +44,28 @@ newtype StateSimple = StateSimple ScrubbedBytes -- just ChaCha's state
     deriving (NFData)
 
 class ChaChaState a where
-    getCounter :: a -> Word64
-    setCounter :: Word64 -> a -> a
+    getCounter64 :: a -> Word64
+    setCounter64 :: Word64 -> a -> a
     getCounter32 :: a -> Word32
     setCounter32 :: Word32 -> a -> a
 
 instance ChaChaState State where
-    getCounter = \(State st) -> getCounter' st
-    setCounter = \n (State st) -> State $ setCounter' n st
+    getCounter64 = \(State st) -> getCounter64' st
+    setCounter64 = \n (State st) -> State $ setCounter64' n st
     getCounter32 = \(State st) -> getCounter32' st
     setCounter32 = \n (State st) -> State $ setCounter32' n st
 
 instance ChaChaState StateSimple where
-    getCounter = \(StateSimple st) -> getCounter' st
-    setCounter = \n (StateSimple st) -> StateSimple $ setCounter' n st
+    getCounter64 = \(StateSimple st) -> getCounter64' st
+    setCounter64 = \n (StateSimple st) -> StateSimple $ setCounter64' n st
     getCounter32 = \(StateSimple st) -> getCounter32' st
     setCounter32 = \n (StateSimple st) -> StateSimple $ setCounter32' n st
 
-getCounter' :: ScrubbedBytes -> Word64
-getCounter' currSt =
+getCounter64' :: ScrubbedBytes -> Word64
+getCounter64' currSt =
     unsafeDoIO $ do
         B.withByteArray currSt $ \stPtr ->
-            ccrypton_chacha_counter stPtr
+            ccrypton_chacha_counter64 stPtr
 
 getCounter32' :: ScrubbedBytes -> Word32
 getCounter32' currSt =
@@ -73,12 +73,12 @@ getCounter32' currSt =
         B.withByteArray currSt $ \stPtr ->
             ccrypton_chacha_counter32 stPtr
 
-setCounter' :: Word64 -> ScrubbedBytes -> ScrubbedBytes
-setCounter' newCounter prevSt =
+setCounter64' :: Word64 -> ScrubbedBytes -> ScrubbedBytes
+setCounter64' newCounter prevSt =
     unsafeDoIO $ do
         newSt <- B.copy prevSt (\_ -> return ())
         B.withByteArray newSt $ \stPtr ->
-            ccrypton_chacha_set_counter stPtr newCounter
+            ccrypton_chacha_set_counter64 stPtr newCounter
         return newSt
 
 setCounter32' :: Word32 -> ScrubbedBytes -> ScrubbedBytes
@@ -249,11 +249,11 @@ foreign import ccall "crypton_chacha_generate"
 foreign import ccall "crypton_chacha_random"
     ccrypton_chacha_random :: Int -> Ptr Word8 -> Ptr StateSimple -> CUInt -> IO ()
 
-foreign import ccall "crypton_chacha_counter"
-    ccrypton_chacha_counter :: Ptr StateSimple -> IO Word64
+foreign import ccall "crypton_chacha_counter64"
+    ccrypton_chacha_counter64 :: Ptr StateSimple -> IO Word64
 
-foreign import ccall "crypton_chacha_set_counter"
-    ccrypton_chacha_set_counter :: Ptr StateSimple -> Word64 -> IO ()
+foreign import ccall "crypton_chacha_set_counter64"
+    ccrypton_chacha_set_counter64 :: Ptr StateSimple -> Word64 -> IO ()
 
 foreign import ccall "crypton_chacha_counter32"
     ccrypton_chacha_counter32 :: Ptr StateSimple -> IO Word32

--- a/Crypto/Cipher/ChaCha.hs
+++ b/Crypto/Cipher/ChaCha.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -263,9 +264,11 @@ foreign import ccall "crypton_chacha_counter32"
 foreign import ccall "crypton_chacha_set_counter32"
     ccrypton_chacha_set_counter32 :: Ptr StateSimple -> Word32 -> IO ()
 
-foreign import ccall "crypton_chacha_get_state"
-    ccrypton_chacha_get_state :: Ptr State -> Ptr StateSimple
-
 foreign import ccall "crypton_chacha_generate_simple_block"
     ccrypton_chacha_generate_simple_block
         :: Ptr Word8 -> Ptr StateSimple -> Word8 -> IO ()
+
+foreign import capi "crypton_chacha.h"
+    crypton_chacha_get_state :: Ptr State -> Ptr StateSimple
+ccrypton_chacha_get_state :: Ptr State -> Ptr StateSimple
+ccrypton_chacha_get_state = crypton_chacha_get_state

--- a/cbits/crypton_chacha.c
+++ b/cbits/crypton_chacha.c
@@ -444,3 +444,7 @@ void crypton_chacha_random(uint32_t rounds, uint8_t *dst, crypton_chacha_state *
 		crypton_chacha_init_core(st, 32, out.b, 8, out.b + 32);
 	}
 }
+
+crypton_chacha_state *crypton_chacha_get_state(crypton_chacha_context *context) {
+  return (&context->st);
+}

--- a/cbits/crypton_chacha.c
+++ b/cbits/crypton_chacha.c
@@ -444,7 +444,3 @@ void crypton_chacha_random(uint32_t rounds, uint8_t *dst, crypton_chacha_state *
 		crypton_chacha_init_core(st, 32, out.b, 8, out.b + 32);
 	}
 }
-
-crypton_chacha_state *crypton_chacha_get_state(crypton_chacha_context *context) {
-  return (&context->st);
-}

--- a/cbits/crypton_chacha.c
+++ b/cbits/crypton_chacha.c
@@ -294,7 +294,7 @@ void crypton_chacha_combine(uint8_t *dst, crypton_chacha_context *ctx, const uin
 	}
 }
 
-uint64_t crypton_chacha_counter(crypton_chacha_state *st)
+uint64_t crypton_chacha_counter64(crypton_chacha_state *st)
 {
 	uint64_t result = ((uint64_t) le32_to_cpu(st->d[12]))
 		| (((uint64_t) le32_to_cpu(st->d[13])) << 32);
@@ -306,7 +306,7 @@ uint32_t crypton_chacha_counter32(crypton_chacha_state *st)
 	return le32_to_cpu(st->d[12]);
 }
 
-void crypton_chacha_set_counter(crypton_chacha_state *st, uint64_t block_counter)
+void crypton_chacha_set_counter64(crypton_chacha_state *st, uint64_t block_counter)
 {
 	uint64_t current_counter;
 	current_counter = ((uint64_t) le32_to_cpu(st->d[12]))

--- a/cbits/crypton_chacha.c
+++ b/cbits/crypton_chacha.c
@@ -301,6 +301,11 @@ uint64_t crypton_chacha_counter(crypton_chacha_state *st)
 	return result;
 }
 
+uint32_t crypton_chacha_counter32(crypton_chacha_state *st)
+{
+	return le32_to_cpu(st->d[12]);
+}
+
 void crypton_chacha_set_counter(crypton_chacha_state *st, uint64_t block_counter)
 {
 	uint64_t current_counter;
@@ -312,6 +317,16 @@ void crypton_chacha_set_counter(crypton_chacha_state *st, uint64_t block_counter
 
 	st->d[12] = cpu_to_le32((uint32_t) block_counter);
 	st->d[13] = cpu_to_le32((uint32_t) (block_counter >> 32));
+}
+
+void crypton_chacha_set_counter32(crypton_chacha_state *st, uint32_t block_counter)
+{
+	uint32_t current_counter = le32_to_cpu(st->d[12]);
+
+	if (current_counter == block_counter)
+		return;
+
+	st->d[12] = cpu_to_le32(block_counter);
 }
 
 void crypton_chacha_generate(uint8_t *dst, crypton_chacha_context *ctx, uint32_t bytes)

--- a/cbits/crypton_chacha.h
+++ b/cbits/crypton_chacha.h
@@ -51,9 +51,9 @@ void crypton_chacha_init(crypton_chacha_context *ctx, uint8_t nb_rounds, uint32_
 void crypton_xchacha_init(crypton_chacha_context *ctx, uint8_t nb_rounds, const uint8_t *key, const uint8_t *iv);
 void crypton_chacha_combine(uint8_t *dst, crypton_chacha_context *st, const uint8_t *src, uint32_t bytes);
 void crypton_chacha_generate(uint8_t *dst, crypton_chacha_context *st, uint32_t bytes);
-uint64_t crypton_chacha_counter(crypton_chacha_state *st);
+uint64_t crypton_chacha_counter64(crypton_chacha_state *st);
 uint32_t crypton_chacha_counter32(crypton_chacha_state *st);
-void crypton_chacha_set_counter(crypton_chacha_state *st, uint64_t block_counter);
+void crypton_chacha_set_counter64(crypton_chacha_state *st, uint64_t block_counter);
 void crypton_chacha_set_counter32(crypton_chacha_state *st, uint32_t block_counter);
 void crypton_chacha_generate_simple_block(uint8_t *dst, crypton_chacha_state *st, uint8_t rounds);
 

--- a/cbits/crypton_chacha.h
+++ b/cbits/crypton_chacha.h
@@ -52,7 +52,9 @@ void crypton_xchacha_init(crypton_chacha_context *ctx, uint8_t nb_rounds, const 
 void crypton_chacha_combine(uint8_t *dst, crypton_chacha_context *st, const uint8_t *src, uint32_t bytes);
 void crypton_chacha_generate(uint8_t *dst, crypton_chacha_context *st, uint32_t bytes);
 uint64_t crypton_chacha_counter(crypton_chacha_state *st);
+uint32_t crypton_chacha_counter32(crypton_chacha_state *st);
 void crypton_chacha_set_counter(crypton_chacha_state *st, uint64_t block_counter);
+void crypton_chacha_set_counter32(crypton_chacha_state *st, uint32_t block_counter);
 void crypton_chacha_generate_simple_block(uint8_t *dst, crypton_chacha_state *st, uint8_t rounds);
 
 #endif

--- a/cbits/crypton_chacha.h
+++ b/cbits/crypton_chacha.h
@@ -56,5 +56,5 @@ uint32_t crypton_chacha_counter32(crypton_chacha_state *st);
 void crypton_chacha_set_counter64(crypton_chacha_state *st, uint64_t block_counter);
 void crypton_chacha_set_counter32(crypton_chacha_state *st, uint32_t block_counter);
 void crypton_chacha_generate_simple_block(uint8_t *dst, crypton_chacha_state *st, uint8_t rounds);
-crypton_chacha_state *crypton_chacha_get_state(crypton_chacha_context *);
+#define crypton_chacha_get_state(context) (&((crypton_chacha_context *) context)->st)
 #endif

--- a/cbits/crypton_chacha.h
+++ b/cbits/crypton_chacha.h
@@ -56,5 +56,5 @@ uint32_t crypton_chacha_counter32(crypton_chacha_state *st);
 void crypton_chacha_set_counter64(crypton_chacha_state *st, uint64_t block_counter);
 void crypton_chacha_set_counter32(crypton_chacha_state *st, uint32_t block_counter);
 void crypton_chacha_generate_simple_block(uint8_t *dst, crypton_chacha_state *st, uint8_t rounds);
-
+crypton_chacha_state *crypton_chacha_get_state(crypton_chacha_context *);
 #endif


### PR DESCRIPTION
Relating #60.

* `getCounter`/`setCounter` is now a method which works for both `State` and `StateSimple`.
* Adding `getCounter32`/`setCounter32`.

@iteratee I confirmed that this can implement QUIC (RFC 9001) via the test vector. Please review this PR.