### PR TITLE
Fix test failures on less common 64-bit arches

### DIFF
--- a/cbits/decaf/include/word.h
+++ b/cbits/decaf/include/word.h
@@ -151,7 +151,7 @@ CRYPTON_DECAF_INLINE mask_t bit_to_mask(uint8_t bit) {
     br_set_to_mask(mask_t x) {
         return vdupq_n_u32(x);
     }
-#elif __amd64__ || __X86_64__ || __aarch64__ /* || _WIN64 -> WIN64 does not support int128 so force the build on arch32 default so do not use this define for _WIN64*/
+#elif __amd64__ || __X86_64__ || __aarch64__ || __loongarch_lp64 || __PPC64__ || __riscv ||  __s390x__ || __alpha__ || __powerpc64__ || (__sparc__ && __arch64__) /* || _WIN64 -> WIN64 does not support int128 so force the build on arch32 default so do not use this define for _WIN64*/
     #define VECTOR_ALIGNED __attribute__((aligned(8)))
     typedef uint64_t big_register_t, uint64xn_t;
 

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -310,13 +310,13 @@ library
     if flag(old_toolchain_inliner)
         cc-options: -fgnu89-inline
 
-    if (arch(x86_64) || arch(aarch64))
+    if (arch(x86_64) || arch(aarch64) || arch(loong64) || arch(ppc64le) || arch(riscv64) || arch(s390x) || arch(alpha) || arch(ppc64) || arch(sparc64))
         include-dirs: cbits/include64
 
     else
         include-dirs: cbits/include32
 
-    if (arch(x86_64) || arch(aarch64))
+    if (arch(x86_64) || arch(aarch64) || arch(loong64) || arch(ppc64le) || arch(riscv64) || arch(s390x) || arch(alpha) || arch(ppc64) || arch(sparc64))
         c-sources:
             cbits/decaf/ed448goldilocks/decaf_all.c
             cbits/decaf/ed448goldilocks/eddsa.c
@@ -340,13 +340,13 @@ library
 
         include-dirs: cbits/decaf/include/arch_32 cbits/decaf/p448/arch_32
 
-    if (arch(x86_64) || arch(aarch64))
+    if (arch(x86_64) || arch(aarch64) || arch(loong64) || arch(ppc64le) || arch(riscv64) || arch(s390x) || arch(alpha) || arch(ppc64) || arch(sparc64))
         c-sources: cbits/curve25519/curve25519-donna-c64.c
 
     else
         c-sources: cbits/curve25519/curve25519-donna.c
 
-    if (arch(i386) || arch(x86_64))
+    if (arch(i386) || arch(x86_64) || arch(loong64) || arch(ppc64le) || arch(riscv64) || arch(alpha))
         cpp-options: -DARCH_IS_LITTLE_ENDIAN
 
     if arch(i386)


### PR DESCRIPTION
This fixes the test failures on ppc64le, s390x, and others on Debian.