### PR TITLE
Fix P256 pointAdd identity behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG for crypton
 
+## 1.1.3
+
+* Ensure that `pointAdd` in `PubKey.ECC.P256` treats the point at infinity as the additive identity.
+  [#73](https://github.com/kazu-yamamoto/crypton/pull/73)
+
 ## 1.1.2
 
 * Preparing `ram` v0.22.

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -110,9 +110,12 @@ toPoint s
 
 -- | Add a point to another point
 pointAdd :: Point -> Point -> Point
-pointAdd a b = withNewPoint $ \dx dy ->
-    withPoint a $ \ax ay -> withPoint b $ \bx by ->
-        ccrypton_p256e_point_add ax ay bx by dx dy
+pointAdd a b
+    | pointIsAtInfinity a = b
+    | pointIsAtInfinity b = a
+    | otherwise = withNewPoint $ \dx dy ->
+        withPoint a $ \ax ay -> withPoint b $ \bx by ->
+            ccrypton_p256e_point_add ax ay bx by dx dy
 
 -- | Negate a point
 pointNegate :: Point -> Point

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.18
 name:               crypton
-version:            1.1.2
+version:            1.1.3
 license:            BSD3
 license-file:       LICENSE
 copyright:          Vincent Hanquez <vincent@snarc.org>

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -180,10 +180,12 @@ tests =
             pe2 = ECC.pointMul curve (unP256 r2) curveGen
             pR = P256.toPoint (P256.scalarAdd (unP256Scalar r1) (unP256Scalar r2))
             peR = ECC.pointAdd curve pe1 pe2
-         in propertyHold
-                [ eqTest "p256" pR (P256.pointAdd p1 p2)
-                , eqTest "ecc" peR (pointP256ToECC pR)
-                ]
+         in (unP256 r1 + unP256 r2) `mod` curveN
+                /= 0
+                    ==> propertyHold
+                        [ eqTest "p256" pR (P256.pointAdd p1 p2)
+                        , eqTest "ecc" peR (pointP256ToECC pR)
+                        ]
 
     propertyPointNegate r =
         let p = P256.toPoint (unP256Scalar r)

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -40,7 +40,9 @@ curveN = ECC.ecc_n . ECC.common_curve $ curve
 curveGen = ECC.ecc_g . ECC.common_curve $ curve
 
 pointP256ToECC :: P256.Point -> ECC.Point
-pointP256ToECC = uncurry ECC.Point . P256.pointToIntegers
+pointP256ToECC p
+    | P256.pointIsAtInfinity p = ECC.PointO
+    | otherwise = uncurry ECC.Point (P256.pointToIntegers p)
 
 i2ospScalar :: Integer -> Bytes
 i2ospScalar i =
@@ -145,8 +147,11 @@ tests =
                     t = P256.pointFromIntegers (xT, yT)
                     r = P256.pointFromIntegers (xR, yR)
                  in r @=? P256.pointAdd s t
+            , testProperty "point-add-infinity" casePointAddInfinity
             , testProperty "lift-to-curve" propertyLiftToCurve
             , testProperty "point-add" propertyPointAdd
+            , testProperty "point-add-infinity-identity" propertyPointAddInfinityIdentity
+            , testProperty "point-add-inverse" propertyPointAddInverse
             , testProperty "point-negate" propertyPointNegate
             , testProperty "point-mul" propertyPointMul
             , testProperty "infinity" $
@@ -175,12 +180,10 @@ tests =
             pe2 = ECC.pointMul curve (unP256 r2) curveGen
             pR = P256.toPoint (P256.scalarAdd (unP256Scalar r1) (unP256Scalar r2))
             peR = ECC.pointAdd curve pe1 pe2
-         in (unP256 r1 + unP256 r2) `mod` curveN
-                /= 0
-                    ==> propertyHold
-                        [ eqTest "p256" pR (P256.pointAdd p1 p2)
-                        , eqTest "ecc" peR (pointP256ToECC pR)
-                        ]
+         in propertyHold
+                [ eqTest "p256" pR (P256.pointAdd p1 p2)
+                , eqTest "ecc" peR (pointP256ToECC pR)
+                ]
 
     propertyPointNegate r =
         let p = P256.toPoint (unP256Scalar r)
@@ -198,4 +201,49 @@ tests =
          in propertyHold
                 [ eqTest "p256" pR (P256.pointMul (unP256Scalar s) p)
                 , eqTest "ecc" peR (pointP256ToECC pR)
+                ]
+
+    pointInfinity :: P256.Point
+    pointInfinity = P256.pointFromIntegers (0, 0)
+
+    casePointAddInfinity =
+        propertyHold
+            [ eqTest
+                "infinity + base"
+                P256.pointBase
+                (P256.pointAdd pointInfinity P256.pointBase)
+            , eqTest
+                "base + infinity"
+                P256.pointBase
+                (P256.pointAdd P256.pointBase pointInfinity)
+            , eqTest
+                "infinity + infinity"
+                pointInfinity
+                (P256.pointAdd pointInfinity pointInfinity)
+            ]
+
+    propertyPointAddInfinityIdentity r =
+        let p = P256.toPoint (unP256Scalar r)
+         in propertyHold
+                [ eqTest
+                    "infinity + p"
+                    p
+                    (P256.pointAdd pointInfinity p)
+                , eqTest
+                    "p + infinity"
+                    p
+                    (P256.pointAdd p pointInfinity)
+                ]
+
+    propertyPointAddInverse r =
+        let p = P256.toPoint (unP256Scalar r)
+         in propertyHold
+                [ eqTest
+                    "p + negate p"
+                    True
+                    (P256.pointIsAtInfinity (P256.pointAdd p (P256.pointNegate p)))
+                , eqTest
+                    "negate p + p"
+                    True
+                    (P256.pointIsAtInfinity (P256.pointAdd (P256.pointNegate p) p))
                 ]


### PR DESCRIPTION
Fixes #62.

`Crypto.PubKey.ECC.P256` represents the point at infinity as `(0,0)`
```haskell
infinity = pointFromIntegers (0,0)
+ = pointAdd
pointIsAtInfinity infinity == True
```
However, `pointAdd` did not treat that value as the additive identity:
```haskell
infinity + pointBase /= pointBase
```

This change fix the Haskell side - detect the point at infinity on either side before calling the C function `crypton_p256e_point_add`.

## Tests

Added direct regression tests `casePointAddInfinity` for:
  - `infinity + pointBase == pointBase`
  - `pointBase +  infinity == pointBase`
  - `infinity + infinity == infinity`
  
Added properties:  
* `propertyPointAddInfinityIdentity` for
  - `infinity + p == p`
  - `p + infinity == p`
* `propertyPointAddInverse` for:
  - `p + negate p == infinity`
  - `negate p + p == infinity`

Existing property: `propertyPointAdd`  is now more general.

## Existing similar approach


https://github.com/kazu-yamamoto/crypton/blob/ddd14236a30438b481bada03018d2d3dea728285/Crypto/PubKey/ECC/Prim.hs#L43-L46

and

https://github.com/kazu-yamamoto/crypton/blob/ddd14236a30438b481bada03018d2d3dea728285/Crypto/ECC/Simple/Prim.hs#L62-L65