### PR TITLE
Add GHC 9.14 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ 'ubuntu-latest', 'macOS-latest', 'windows-latest' ]
-        ghc: [ '9.2', '9.4', '9.6', '9.8', '9.10', '9.12' ]
+        ghc: [ '9.2', '9.4', '9.6', '9.8', '9.10', '9.12', '9.14' ]
 
     env:
       cache-name: cabal-ghc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: haskell-actions/setup@v2
       with:
@@ -40,7 +40,7 @@ jobs:
         echo "ghc_version=$ghc_version" >> "$GITHUB_OUTPUT"
 
     - name: Restore Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       if: ${{ github.ref_name != 'ci-uc' }}
       with:
         path: ~/.cabal
@@ -59,7 +59,7 @@ jobs:
         fi
 
     - name: Save Cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: ${{ steps.inst-dep.outputs.installed == 'true' || steps.doctest-dep.outputs.installed == 'true' }}
       with:
         path: ~/.cabal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ 'ubuntu-latest', 'macOS-latest', 'windows-latest' ]
-        ghc: [ '9.2', '9.4', '9.6', '9.8', '9.10', '9.12', '9.14' ]
+        ghc: [ '9.2.8', '9.4.8', '9.6.7', '9.8.4', '9.10.2', '9.12.2', '9.14.1' ]
 
     env:
       cache-name: cabal-ghc

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -8,7 +8,7 @@ maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>
 author:             Vincent Hanquez <vincent@snarc.org>
 stability:          experimental
 tested-with:
-    ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.1 || ==9.12.1
+    ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 homepage:           https://github.com/kazu-yamamoto/crypton
 bug-reports:        https://github.com/kazu-yamamoto/crypton/issues

--- a/crypton.cabal
+++ b/crypton.cabal
@@ -8,7 +8,7 @@ maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>
 author:             Vincent Hanquez <vincent@snarc.org>
 stability:          experimental
 tested-with:
-    ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
+    ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2 || ==9.14.1
 
 homepage:           https://github.com/kazu-yamamoto/crypton
 bug-reports:        https://github.com/kazu-yamamoto/crypton/issues


### PR DESCRIPTION
* add GHC 9.14 to CI matrix
* update of actions to avoid warning (GH [recommends migrating from old actions using Node 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/))
* align GHC versions in CI build matrix with what is declared in cabal file