### PR TITLE
fix(p256): prevent crashes when validating valid points

### DIFF
--- a/cbits/p256/p256.c
+++ b/cbits/p256/p256.c
@@ -104,7 +104,9 @@ static crypton_p256_digit subTop(crypton_p256_digit top_a,
   borrow += top_c;
   borrow -= top_a;
   top_c = (crypton_p256_digit)borrow;
-  assert((borrow >> P256_BITSPERDIGIT) == 0);
+  /* A borrow out is a legitimate outcome: the quotient estimate in
+     crypton_p256_modmul can exceed the true quotient by one.  Report it in
+     the returned top digit (all ones) and let the caller correct. */
   return top_c;
 }
 
@@ -177,6 +179,13 @@ void crypton_p256_modmul(const crypton_p256_int* MOD,
 
     // Subtract reducer from top | tmp.
     top = subTop(top_reducer, reducer, top, tmp + i);
+
+    // The quotient estimate above can exceed the true quotient by one --
+    // with 64-bit digits, whenever the low half of top is zero and the
+    // digits below it are small -- and the subtraction then borrows.  The
+    // deficit is always less than MOD, so adding MOD back once restores
+    // the invariant.
+    top = addM(MOD, top, tmp + i, 0 - (top >> (P256_BITSPERDIGIT - 1)));
 
     // top is now either 0 or 1. Make it 0, fixed-timing.
     assert(top <= 1);

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -73,6 +73,14 @@ yT = 0x5421c3209c2d6c704835d82ac4c3dd90f61a8a52598b9e7ab656e9d8c8b24316
 xR = 0x72b13dd4354b6b81745195e98cc5ba6970349191ac476bd4553cf35a545a067e
 yR = 0x8d585cbb2e1327d75241a8a122d7620dc33b13315aa5c9d46d013011744ac264
 
+-- Two points on the curve whose validation reduces a product whose top
+-- digit has a zero low half: x = 2^96, and an x with a repeating bit
+-- pattern.  Wycheproof ecdh_secp256r1_ecpoint tcId 74 and 93.
+xU = 0x0000000000000000000000000000000000000001000000000000000000000000
+yU = 0x7d12de58d54423eb85ae8d157ae416fb004a7eb522ac1b67047ef3cdf9acdc3f
+xV = 0x8000003ffffff0000007fffffe000000ffffffc000001ffffff8000003fffffc
+yV = 0x0c3527bd081c1c07b313bc1a0c3f845fb2fe22557699ccc8f1354e61a27b7f88
+
 tests =
     testGroup
         "P256"
@@ -142,6 +150,12 @@ tests =
             , testCase "valid-point-1" $ casePointIsValid (xS, yS)
             , testCase "valid-point-2" $ casePointIsValid (xR, yR)
             , testCase "valid-point-3" $ casePointIsValid (xT, yT)
+            , -- The quotient estimate in crypton_p256_modmul can exceed the
+              -- true quotient, and the resulting borrow used to abort the
+              -- process on an assertion inside the reduction rather than
+              -- being corrected.  Both points below are on the curve.
+              testCase "valid-point-reduction-1" $ casePointIsValid (xU, yU)
+            , testCase "valid-point-reduction-2" $ casePointIsValid (xV, yV)
             , testCase "point-add-1" $
                 let s = P256.pointFromIntegers (xS, yS)
                     t = P256.pointFromIntegers (xT, yT)


### PR DESCRIPTION
## Summary

Fix a process-aborting assertion in the 64-bit P-256 implementation when validating certain valid points. The crash is reachable through `Crypto.PubKey.ECC.P256.pointFromBinary` and the typed `Crypto.ECC` decoder, including applications decoding untrusted public keys for ECDH or ECDSA.

The issue was found using two `EdgeCaseEphemeralKey` cases in [Wycheproof’s P-256 ECDH test vectors](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/ecdh_secp256r1_ecpoint_test.json). Both are marked `valid`:

| Case | Input characteristic | Failure before the fix |
| --- | --- | --- |
| tcId 74 | `x = 2^96` | Aborts while computing `x · x²` |
| tcId 93 | x-coordinate with a repeating 51-bit pattern | Aborts while computing `x · x` |

P-256’s parameters are defined in [NIST SP 800-186, §3.2.1.3](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186.pdf#page=21). Validation routine is described in [NIST SP 800-56A Rev. 3, §§5.6.2.3.3–5.6.2.3.4](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf#page=55).

## Changes

With 64-bit digits, `crypton_p256_modmul` estimates each quotient digit as `top + (top >> 32)`. The estimate can exceed the correct quotient by one, causing subtraction to underflow and triggering the assertion in `subTop`. With `NDEBUG`, the original code instead produces incorrect multiplication results.

Changes done:

- Allow `subTop` to return the borrow instead of asserting that subtraction never underflows.
- Add the modulus back once when a borrow occurs. The deficit is less than one modulus for both moduli used by this routine, so one correction is sufficient.
- Use masked arithmetic without introducing a data-dependent branch.
- Add the two Wycheproof points as regression tests.

## Tests

- All tests pass, including both new regression cases.
- Reproduced both original crashes and the incorrect results with `NDEBUG`.