### PR TITLE
fix(aes): refuse a zero-length AES-GCM IV

### DIFF
--- a/Crypto/Cipher/AES.hs
+++ b/Crypto/Cipher/AES.hs
@@ -55,7 +55,7 @@ instance BlockCipher CSTR where \
     ; cbcEncrypt (CSTR aes) (IV iv) = encryptCBC aes (IV iv) \
     ; cbcDecrypt (CSTR aes) (IV iv) = decryptCBC aes (IV iv) \
     ; ctrCombine (CSTR aes) (IV iv) = encryptCTR aes (IV iv) \
-    ; aeadInit AEAD_GCM (CSTR aes) iv = CryptoPassed $ AEAD (gcmMode aes) (gcmInit aes iv) \
+    ; aeadInit AEAD_GCM (CSTR aes) iv = gcmAeadInit aes iv \
     ; aeadInit AEAD_OCB (CSTR aes) iv = CryptoPassed $ AEAD (ocbMode aes) (ocbInit aes iv) \
     ; aeadInit (AEAD_CCM n m l) (CSTR aes) iv = AEAD (ccmMode aes) <$> ccmInit aes iv n m l \
     ; aeadInit _        _          _  = CryptoFailed CryptoError_AEADModeNotSupported \

--- a/Crypto/Cipher/AES/Primitive.hs
+++ b/Crypto/Cipher/AES/Primitive.hs
@@ -42,6 +42,7 @@ module Crypto.Cipher.AES.Primitive (
     -- * Incremental GCM
     gcmMode,
     gcmInit,
+    gcmAeadInit,
 
     -- * Incremental OCB
     ocbMode,
@@ -84,13 +85,22 @@ instance BlockCipher AES where
     cbcEncrypt = encryptCBC
     cbcDecrypt = decryptCBC
     ctrCombine = encryptCTR
-    aeadInit AEAD_GCM aes iv = CryptoPassed $ AEAD (gcmMode aes) (gcmInit aes iv)
+    aeadInit AEAD_GCM aes iv = gcmAeadInit aes iv
     aeadInit AEAD_OCB aes iv = CryptoPassed $ AEAD (ocbMode aes) (ocbInit aes iv)
     aeadInit (AEAD_CCM n m l) aes iv = AEAD (ccmMode aes) <$> ccmInit aes iv n m l
     aeadInit _ _ _ = CryptoFailed CryptoError_AEADModeNotSupported
 instance BlockCipher128 AES where
     xtsEncrypt = encryptXTS
     xtsDecrypt = decryptXTS
+
+-- | Create an AES AEAD context for GCM, refusing the zero-length IV that
+-- SP 800-38D 5.2.1.1 forbids: any length other than 96 bits is fed to
+-- GHASH, and for the empty IV that makes J0 the GHASH of the empty
+-- string, which leaks the authentication key.
+gcmAeadInit :: ByteArrayAccess iv => AES -> iv -> CryptoFailable (AEAD c)
+gcmAeadInit aes iv
+    | B.length iv == 0 = CryptoFailed CryptoError_IvSizeInvalid
+    | otherwise = CryptoPassed $ AEAD (gcmMode aes) (gcmInit aes iv)
 
 -- | Create an AES AEAD implementation for GCM
 gcmMode :: AES -> AEADModeImpl AESGCM

--- a/tests/KAT_AES.hs
+++ b/tests/KAT_AES.hs
@@ -5,6 +5,7 @@ module KAT_AES (tests) where
 import BlockCipher
 import qualified Crypto.Cipher.AES as AES
 import Crypto.Cipher.Types
+import Crypto.Error
 import qualified Data.ByteString as B
 import Data.Maybe
 import Imports
@@ -113,12 +114,32 @@ kats256 =
         , kat_AEAD = map toKatGCM KATGCM.vectors_aes256_enc
         }
 
+-- SP 800-38D 5.2.1.1: 1 <= len(IV) <= 2^64 - 1.  A zero-length IV makes
+-- J0 the GHASH of the empty string, which leaks the authentication key.
+aeadIVLengthTests :: TestTree
+aeadIVLengthTests =
+    testGroup
+        "AEAD IV length"
+        [ testCase "96-bit IV accepted" $
+            True @=? isRight (initWith (B.replicate 12 0))
+        , testCase "8-bit IV accepted" $
+            True @=? isRight (initWith (B.replicate 1 0))
+        , testCase "empty IV rejected" $
+            Left CryptoError_IvSizeInvalid @=? initWith B.empty
+        ]
+  where
+    ctx = throwCryptoError (cipherInit (B.replicate 16 0)) :: AES.AES128
+    initWith iv =
+        eitherCryptoError (() <$ aeadInit AEAD_GCM ctx (iv :: ByteString))
+    isRight = either (const False) (const True)
+
 tests =
     testGroup
         "AES"
         [ testBlockCipher kats128 (undefined :: AES.AES128)
         , testBlockCipher kats192 (undefined :: AES.AES192)
         , testBlockCipher kats256 (undefined :: AES.AES256)
+        , aeadIVLengthTests
         {-
             , testProperty "genCtr" $ \(key, iv1) ->
                 let (bs1, iv2)    = AES.genCounter key iv1 32


### PR DESCRIPTION
## Summary

Reject zero-length AES-GCM IVs. [NIST SP 800-38D §5.2.1.1](https://doi.org/10.6028/NIST.SP.800-38D) requires a non-empty IV. An empty IV can expose the authentication key. Found through Wycheproof [`ZeroLengthIv` vectors](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/aes_gcm_test.json#L4896-L5014).

## Changes

- Return `CryptoError_IvSizeInvalid` for empty IVs.
- Apply validation to all AES-GCM variants.

## Tests

Added coverage confirming 96-bit and 8-bit IVs are accepted while empty IVs are rejected.