### PR TITLE
fix(aead): reject undersized tags

### DIFF
--- a/Crypto/Cipher/Types/AEAD.hs
+++ b/Crypto/Cipher/Types/AEAD.hs
@@ -69,7 +69,22 @@ aeadSimpleEncrypt aeadIni header input taglen = (tag, output)
     (output, aeadFinal) = aeadEncrypt aead input
     tag = aeadFinalize aeadFinal taglen
 
+-- | The shortest authentication tag any mode here produces, four bytes
+-- (@CCM_M4@).  Modes that truncate their tag -- GCM and OCB3 -- will
+-- compute one of whatever length they are asked for, down to nothing, so
+-- 'aeadSimpleDecrypt' refuses a shorter tag than this rather than
+-- authenticate fewer bytes than any supported mode ever emits.
+minimumTagLength :: Int
+minimumTagLength = 4
+
 -- | Simple AEAD decryptio.
+--
+-- The number of bytes compared is the length of @authTag@.  That is the
+-- caller's choice of tag length, so a caller reading a tag off the wire
+-- must check its length against the one it expects: passing an
+-- attacker-supplied tag straight in lets the attacker pick how much of it
+-- is verified.  Tags shorter than 'minimumTagLength' are rejected
+-- outright.
 aeadSimpleDecrypt
     :: (ByteArrayAccess aad, ByteArray ba)
     => AEAD a
@@ -83,6 +98,7 @@ aeadSimpleDecrypt
     -> Maybe ba
     -- ^ Plaintext
 aeadSimpleDecrypt aeadIni header input authTag
+    | B.length authTag < minimumTagLength = Nothing
     | tag == authTag = Just output
     | otherwise = Nothing
   where

--- a/tests/KAT_AES.hs
+++ b/tests/KAT_AES.hs
@@ -5,6 +5,8 @@ module KAT_AES (tests) where
 import BlockCipher
 import qualified Crypto.Cipher.AES as AES
 import Crypto.Cipher.Types
+import Crypto.Error
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import Data.Maybe
 import Imports
@@ -113,12 +115,35 @@ kats256 =
         , kat_AEAD = map toKatGCM KATGCM.vectors_aes256_enc
         }
 
+aeadTagLengthTests :: TestTree
+aeadTagLengthTests =
+    testGroup
+        "AEAD tag length"
+        [ testCase "full tag verifies" $ Just message @=? openWith fullTag
+        , testCase "empty tag rejected" $ Nothing @=? openWith B.empty
+        , testCase "1-byte tag rejected" $ Nothing @=? openWith (B.take 1 fullTag)
+        , testCase "3-byte tag rejected" $ Nothing @=? openWith (B.take 3 fullTag)
+        , testCase "wrong tag rejected" $
+            Nothing @=? openWith (B.map (+ 1) fullTag)
+        ]
+  where
+    key = B.replicate 16 0
+    iv = B.replicate 12 0
+    aad = "additional data" :: ByteString
+    message = "authenticated message" :: ByteString
+    ctx = throwCryptoError (cipherInit key) :: AES.AES128
+    aead = throwCryptoError (aeadInit AEAD_GCM ctx iv)
+    (AuthTag tag, ciphertext) = aeadSimpleEncrypt aead aad message 16
+    fullTag = BA.convert tag :: ByteString
+    openWith t = aeadSimpleDecrypt aead aad ciphertext (AuthTag (BA.convert t))
+
 tests =
     testGroup
         "AES"
         [ testBlockCipher kats128 (undefined :: AES.AES128)
         , testBlockCipher kats192 (undefined :: AES.AES192)
         , testBlockCipher kats256 (undefined :: AES.AES256)
+        , aeadTagLengthTests
         {-
             , testProperty "genCtr" $ \(key, iv1) ->
                 let (bs1, iv2)    = AES.genCounter key iv1 32


### PR DESCRIPTION
## Summary

`aeadSimpleDecrypt` compares only as many tag bytes as the caller supplies, so an attacker who controls the tag controls how much of it is checked. With GCM, an empty tag verifies any ciphertext.

The issue was found by mutation-testing [Wycheproof’s AES-GCM vectors](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/aes_gcm_test.json). Valid vectors were replayed with truncated tags. Crypton accepted all 229 mutations because it recomputed the tag at the supplied length.

[NIST SP 800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf#page=16) defines the tag length as an authentication security parameter.

## Changes

- Reject tags shorter than four bytes. The shortest this library emits (`CCM_M4`) and the minimum [SP 800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf)  §5.2.1.2 allows.
- Document expected-length validation.
- Add an AES-GCM regression test

## Tests

Full test suite passes.

