### PR TITLE
fix(ed25519): reject non-canonical signatures

### DIFF
--- a/Crypto/PubKey/EdDSA.hs
+++ b/Crypto/PubKey/EdDSA.hs
@@ -390,11 +390,13 @@ decodeSignature
     => proxy curve
     -> Signature curve hash
     -> CryptoFailable (Bytes, Point curve, Scalar curve)
-decodeSignature prx (Signature bs) = do
+decodeSignature prx sig@(Signature bs) = do
     let (bsR, bsS) = B.splitAt (publicKeySize prx) bs
     pR <- decodePoint prx bsR
     sS <- decodeScalarLE prx bsS
-    return (bsR, pR, sS)
+    if encodeSignature prx (encodePoint prx pR, pR, sS) == sig
+        then return (bsR, pR, sS)
+        else CryptoFailed CryptoError_PointFormatInvalid
 
 -- implementations are supposed to decode any scalar up to the size of the digest
 decodeScalarNoErr

--- a/cbits/ed25519/ed25519.c
+++ b/cbits/ed25519/ed25519.c
@@ -89,7 +89,7 @@ ED25519_FN(ed25519_sign_open) (const unsigned char *m, size_t mlen, const ed2551
 	ge25519 ALIGN(16) R, A;
 	hash_512bits hash;
 	bignum256modm hram, S;
-	unsigned char checkR[32];
+	unsigned char checkR[32], checkS[32];
 
 	if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
 		return -1;
@@ -100,6 +100,11 @@ ED25519_FN(ed25519_sign_open) (const unsigned char *m, size_t mlen, const ed2551
 
 	/* S */
 	expand256_modm(S, RS + 32, 32);
+
+	/* check that S is canonical */
+	contract256_modm(checkS, S);
+	if (!ed25519_verify(RS + 32, checkS, 32))
+		return -1;
 
 	/* SB - H(R,A,m)A */
 	ge25519_double_scalarmult_vartime(&R, &A, hram, S);

--- a/tests/KAT_Ed25519.hs
+++ b/tests/KAT_Ed25519.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module KAT_Ed25519 (tests) where
 
 import Crypto.Error
 import qualified Crypto.PubKey.Ed25519 as Ed25519
+import Data.ByteArray.Encoding (Base (Base16), convertFromBase)
 import Imports
 
 data Vec = Vec
@@ -81,6 +83,46 @@ doVerifyTest i vec = testCase (show i) (True @=? Ed25519.verify pub (vecMsg vec)
     !sig = throwCryptoError $ Ed25519.signature (vecSig vec)
     !pub = throwCryptoError $ Ed25519.publicKey (vecPub vec)
 
+unhex :: ByteString -> ByteString
+unhex = either error id . convertFromBase Base16
+
+-- | Invalid signatures from Wycheproof's ed25519_test.json.
+data NegVec = NegVec
+    { negTc :: Int
+    , negWhy :: String
+    , negPub :: ByteString
+    , negMsg :: ByteString
+    , negSig :: ByteString
+    }
+
+negVectors =
+    [ NegVec
+        { negTc = 63
+        , negWhy = "s replaced by s + L"
+        , negPub = unhex "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+        , negMsg = unhex "54657374"
+        , negSig =
+            unhex
+                "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab067654bce3832c2d76f8f6f5dafc08d9339d4eef676573336a5c51eb6f946b31d"
+        }
+    , NegVec
+        { negTc = 85
+        , negWhy = "s just above the bound"
+        , negPub = unhex "100fdf47fb94f1536a4f7c3fda27383fa03375a8f527c537e6f1703c47f94f86"
+        , negMsg = unhex "6a0bc2b0057cedfc0fa2e3f7f7d39279b30f454a69dfd1117c758d86b19d85e0"
+        , negSig =
+            unhex
+                "0971f86d2c9c78582524a103cb9cf949522ae528f8054dc20107d999be673ff4e25ebf2f2928766b1248bec6e91697775f8446639ede46ad4df4053000000010"
+        }
+    ]
+
+doNegVerifyTest :: NegVec -> TestTree
+doNegVerifyTest NegVec{..} =
+    testCase (show negTc ++ ": " ++ negWhy) (False @=? Ed25519.verify pub negMsg sig)
+  where
+    !sig = throwCryptoError $ Ed25519.signature negSig
+    !pub = throwCryptoError $ Ed25519.publicKey negPub
+
 tests =
     testGroup
         "Ed25519"
@@ -88,4 +130,5 @@ tests =
         , testGroup "gen publickey" $ zipWith doPublicKeyTest [katZero ..] vectors
         , testGroup "gen signature" $ zipWith doSignatureTest [katZero ..] vectors
         , testGroup "verify sig" $ zipWith doVerifyTest [katZero ..] vectors
+        , testGroup "reject non-canonical scalar" $ map doNegVerifyTest negVectors
         ]

--- a/tests/KAT_EdDSA.hs
+++ b/tests/KAT_EdDSA.hs
@@ -12,6 +12,7 @@ import Crypto.Error
 import Crypto.Hash.Algorithms
 import Crypto.Hash.IO
 import qualified Crypto.PubKey.EdDSA as EdDSA
+import Data.ByteArray.Encoding (Base (Base16), convertFromBase)
 import Imports
 
 data Vec
@@ -156,10 +157,76 @@ doVerifyTest i Vec{..} =
     !sig = throwCryptoError $ EdDSA.signature vecPrx vecAlg vecSig
     !pub = throwCryptoError $ EdDSA.publicKey vecPrx vecAlg vecPub
 
+unhex :: ByteString -> ByteString
+unhex = either error id . convertFromBase Base16
+
+-- | Invalid signatures from Wycheproof's ed25519_test.json.
+data NegVec
+    = forall curve hash.
+      ( EdDSA.EllipticCurveEdDSA curve
+      , HashAlgorithm hash
+      , HashDigestSize hash ~ EdDSA.CurveDigestSize curve
+      ) =>
+    NegVec
+    { negPrx :: Maybe curve
+    , negAlg :: hash
+    , negTc :: Int
+    , negWhy :: String
+    , negPub :: ByteString
+    , negMsg :: ByteString
+    , negSig :: ByteString
+    }
+
+negVectors =
+    [ ed25519Neg 63 "s replaced by s + L"
+        "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+        "54657374"
+        "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab067654bce3832c2d76f8f6f5dafc08d9339d4eef676573336a5c51eb6f946b31d"
+    , ed25519Neg 64 "s replaced by s + 2L"
+        "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+        "54657374"
+        "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab05439412b5395d42f462c67008eba6ca839d4eef676573336a5c51eb6f946b32d"
+    , ed25519Neg 65 "s replaced by s + 4L"
+        "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+        "54657374"
+        "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab02ee12ce5875bf9dff26556464bae2ad239d4eef676573336a5c51eb6f946b34d"
+    , ed25519Neg 66 "s replaced by s + 8L"
+        "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+        "54657374"
+        "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab0e2300459f1e742404cd934d2c595a6253ad4eef676573336a5c51eb6f946b38d"
+    , ed25519Neg 85 "s just above the bound"
+        "100fdf47fb94f1536a4f7c3fda27383fa03375a8f527c537e6f1703c47f94f86"
+        "6a0bc2b0057cedfc0fa2e3f7f7d39279b30f454a69dfd1117c758d86b19d85e0"
+        "0971f86d2c9c78582524a103cb9cf949522ae528f8054dc20107d999be673ff4e25ebf2f2928766b1248bec6e91697775f8446639ede46ad4df4053000000010"
+    , ed25519Neg 151 "R encodes y = 1 with the sign bit of x set"
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+        "313233343030"
+        "0100000000000000000000000000000000000000000000000000000000000080c803ee1f2342aa96ff698a393d1ab5e66f3eda101d6d120b394c3fd32c117d0a"
+    ]
+  where
+    ed25519Neg tc why pub msg sig =
+        NegVec
+            { negPrx = Just Curve_Edwards25519
+            , negAlg = SHA512
+            , negTc = tc
+            , negWhy = why
+            , negPub = unhex pub
+            , negMsg = unhex msg
+            , negSig = unhex sig
+            }
+
+doNegVerifyTest :: NegVec -> TestTree
+doNegVerifyTest NegVec{..} =
+    testCase (show negTc ++ ": " ++ negWhy) (False @=? EdDSA.verify negPrx pub negMsg sig)
+  where
+    !sig = throwCryptoError $ EdDSA.signature negPrx negAlg negSig
+    !pub = throwCryptoError $ EdDSA.publicKey negPrx negAlg negPub
+
 tests =
     testGroup
         "EdDSA"
         [ testGroup "gen publickey" $ zipWith doPublicKeyTest [katZero ..] vectors
         , testGroup "gen signature" $ zipWith doSignatureTest [katZero ..] vectors
         , testGroup "verify sig" $ zipWith doVerifyTest [katZero ..] vectors
+        , testGroup "reject non-canonical encoding" $ map doNegVerifyTest negVectors
         ]


### PR DESCRIPTION
## Summary

Reject non-canonical Ed25519 signatures in both verification paths. [RFC 8032 Section 5.1.7](https://www.rfc-editor.org/rfc/rfc8032.html#section-5.1.7) and [NIST FIPS 186-5 Section 7.7](https://doi.org/10.6028/NIST.FIPS.186-5) require `S` to be in the range `0 <= S < L`. This change prevents signature malleability.

The regression cases come from the [Project Wycheproof Ed25519 vectors](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/ed25519_test.json).

## Changes

The donna-backed verifier serializes the reduced scalar and compares it with the supplied `S`, rejecting values that were reduced modulo `L`.

The generic verifier re-encodes the decoded signature before verification. This rejects both out-of-range scalar encodings and non-canonical point encodings, including `y = 1` with the sign bit set when `x = 0`.

## Tests

All tests pass.
