### PR TITLE
fix(hkdf): enforce RFC 5869 output limit

### DIFF
--- a/Crypto/KDF/HKDF.hs
+++ b/Crypto/KDF/HKDF.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- Module      : Crypto.KDF.HKDF
@@ -18,6 +19,7 @@ module Crypto.KDF.HKDF (
     toPRK,
 ) where
 
+import Crypto.Error
 import Crypto.Hash
 import Crypto.Internal.ByteArray (
     ByteArray,
@@ -60,8 +62,12 @@ extractSkip
 extractSkip ikm = PRK_NoExpand $ B.convert ikm
 
 -- | Expand key material of specific length out of the parameters
+--
+-- Requests exceeding the RFC 5869 limit of @255 * HashLen@ raise
+-- 'CryptoError_OutputLengthTooBig'.
 expand
-    :: (HashAlgorithm a, ByteArrayAccess info, ByteArray out)
+    :: forall a info out
+     . (HashAlgorithm a, ByteArrayAccess info, ByteArray out)
     => PRK a
     -- ^ Pseudo Random Key
     -> info
@@ -70,9 +76,12 @@ expand
     -- ^ Output length in bytes
     -> out
     -- ^ Output data
-expand prkAt infoAt outputLength =
-    let hF = hFGet prkAt
-     in B.concat $ loop hF B.empty outputLength 1
+expand prkAt infoAt outputLength
+    | outputLength > 255 * hashDigestSize (undefined :: a) =
+        throwCryptoError (CryptoFailed CryptoError_OutputLengthTooBig)
+    | otherwise =
+        let hF = hFGet prkAt
+         in B.concat $ loop hF B.empty outputLength 1
   where
     hFGet :: (HashAlgorithm a, ByteArrayAccess b) => PRK a -> (b -> HMAC a)
     hFGet prk = case prk of

--- a/tests/KAT_HKDF.hs
+++ b/tests/KAT_HKDF.hs
@@ -2,7 +2,9 @@
 
 module KAT_HKDF (tests) where
 
-import Crypto.Hash (HashAlgorithm, SHA256 (..))
+import Control.Exception (evaluate, try)
+import Crypto.Error (CryptoError (..))
+import Crypto.Hash (HashAlgorithm, SHA1, SHA256, SHA384, SHA512)
 import qualified Crypto.KDF.HKDF as HKDF
 import qualified Data.ByteString as B
 
@@ -380,8 +382,34 @@ kdfTests =
     is :: [Int]
     is = [1 ..]
 
+boundTests :: [TestTree]
+boundTests =
+    [ boundTest "SHA-1" (HKDF.extract salt ikm :: HKDF.PRK SHA1) 20
+    , boundTest "SHA-256" (HKDF.extract salt ikm :: HKDF.PRK SHA256) 32
+    , boundTest "SHA-384" (HKDF.extract salt ikm :: HKDF.PRK SHA384) 48
+    , boundTest "SHA-512" (HKDF.extract salt ikm :: HKDF.PRK SHA512) 64
+    ]
+  where
+    salt = "salt" :: ByteString
+    ikm = "input key material" :: ByteString
+    info = "info" :: ByteString
+    boundTest name prk hashLen =
+        testGroup
+            name
+            [ testCase "maximum length" $
+                maxLen @=? B.length (HKDF.expand prk info maxLen :: ByteString)
+            , testCase "one byte past the maximum" $ do
+                result <-
+                    try (evaluate (B.length (HKDF.expand prk info (maxLen + 1) :: ByteString)))
+                        :: IO (Either CryptoError Int)
+                Left CryptoError_OutputLengthTooBig @=? result
+            ]
+      where
+        maxLen = 255 * hashLen
+
 tests =
     testGroup
         "HKDF"
         [ testGroup "KATs" kdfTests
+        , testGroup "output bound" boundTests
         ]


### PR DESCRIPTION
## Summary

Fix `Crypto.KDF.HKDF.expand` accepting output lengths greater than `255 × HashLen`. [RFC 5869 §2.3](https://www.rfc-editor.org/rfc/rfc5869.html#section-2.3) defines this limit because HKDF-Expand uses a one-octet block counter. [NIST SP 800-56C Rev. 2 §5.1](https://doi.org/10.6028/NIST.SP.800-56Cr2) describes RFC 5869 as an HMAC-based extraction-then-expansion procedure and requires an error when the requested output is too large for the selected KDF.

The issue was found through [Project Wycheproof's HKDF-SHA-256 `SizeTooLarge` vectors](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/hkdf_sha256_test.json#L25-L27), including tcIds 25, 48, and 74. Without the check, the `Word8` counter wrapped at block 256 and expansion continued with non-RFC output.

## Changes

- Reject HKDF-Expand requests above `255 × HashLen` with `CryptoError_OutputLengthTooBig`.
- Document the output-length requirement on `expand`.
- Add boundary and oversized-output regression tests for SHA-1, SHA-256, SHA-384, and SHA-512.

## Tests

All tests pass. This PR also has a regression test in the first commit (which fails), then the fix (and tests pass).