### PR TITLE
fix(p256): accept valid edge-case points

### DIFF
--- a/cbits/p256/p256.c
+++ b/cbits/p256/p256.c
@@ -352,13 +352,12 @@ void crypton_p256_mod(const crypton_p256_int* MOD,
 }
 
 // Verify y^2 == x^3 - 3x + b mod p
-// and 0 < x < p and 0 < y < p
+// and 0 <= x < p and 0 < y < p
 int crypton_p256_is_valid_point(const crypton_p256_int* x, const crypton_p256_int* y) {
   crypton_p256_int y2, x3;
 
   if (crypton_p256_cmp(&crypton_SECP256r1_p, x) <= 0 ||
       crypton_p256_cmp(&crypton_SECP256r1_p, y) <= 0 ||
-      crypton_p256_is_zero(x) ||
       crypton_p256_is_zero(y)) return 0;
 
   crypton_p256_modmul(&crypton_SECP256r1_p, y, 0, y, &y2);  // y^2
@@ -370,6 +369,7 @@ int crypton_p256_is_valid_point(const crypton_p256_int* x, const crypton_p256_in
   if (crypton_p256_sub(&x3, x, &x3)) crypton_p256_add(&x3, &crypton_SECP256r1_p, &x3);  // x^3 - 3x
   if (crypton_p256_add(&x3, &crypton_SECP256r1_b, &x3))  // x^3 - 3x + b
     crypton_p256_sub(&x3, &crypton_SECP256r1_p, &x3);
+  crypton_p256_mod(&crypton_SECP256r1_p, &x3, &x3);
 
   return crypton_p256_cmp(&y2, &x3) == 0;
 }

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -81,6 +81,15 @@ yU = 0x7d12de58d54423eb85ae8d157ae416fb004a7eb522ac1b67047ef3cdf9acdc3f
 xV = 0x8000003ffffff0000007fffffe000000ffffffc000001ffffff8000003fffffc
 yV = 0x0c3527bd081c1c07b313bc1a0c3f845fb2fe22557699ccc8f1354e61a27b7f88
 
+validPointEdgeCases :: [(String, (Integer, Integer))]
+validPointEdgeCases =
+    [ ("x-zero-1", (0, 0x66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4))
+    , ("x-zero-2", (0, 0x99b7a386f1d07c29dbcc42a27b5f9449abe3d50de25178e8d7407a95e8b06c0b))
+    , ("y-one-1", (0x09e78d4ef60d05f750f6636209092bc43cbdd6b47e11a9de20a9feb2a50bb96c, 1))
+    , ("y-one-2", (0x8d0177ebab9c6e9e10db6dd095dbac0d6375e8a97b70f611875d877f0069d2c7, 1))
+    , ("y-one-3", (0x6916fac45e568b6b9e2e2ecd611b282e5fcc40a3067d601057f879ce5a8a73cc, 1))
+    ]
+
 tests =
     testGroup
         "P256"
@@ -156,6 +165,8 @@ tests =
               -- being corrected.  Both points below are on the curve.
               testCase "valid-point-reduction-1" $ casePointIsValid (xU, yU)
             , testCase "valid-point-reduction-2" $ casePointIsValid (xV, yV)
+            , testGroup "valid-point-edge-cases" $
+                map (\(name, point) -> testCase name $ casePointIsValid point) validPointEdgeCases
             , testCase "point-add-1" $
                 let s = P256.pointFromIntegers (xS, yS)
                     t = P256.pointFromIntegers (xT, yT)


### PR DESCRIPTION
## Summary

Fix P-256 public-point validation to match [NIST SP 800-186, Section 2.1.1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186.pdf#page=15). It defines a valid affine point as coordinates that satisfy the curve equation. [Sections 3.2.1–3.2.1.3](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186.pdf#page=20) define that equation modulo `p` and give the P-256 parameters. Therefore, `x = 0` is valid when it satisfies the equation, and both sides must be reduced modulo `p` before comparison.

The validator rejected points with `x = 0` and points whose reduced `y²` is small because the other side of the curve equation was not fully reduced.

This was discovered by replaying [Wycheproof `ecdh_secp256r1_ecpoint_test.json`](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/ecdh_secp256r1_ecpoint_test.json).

## Changes

- Accept valid P-256 points with a zero x-coordinate.
- Reduce `x³ - 3x + b` modulo p before comparing it with `y²`.
- Cover both zero-x points and all three y=1 edge cases.

## Tests

All five new edge-case tests fail as expected in the regression test commit, and pass after fix commit.
