### PR TITLE
fix(ecc): accept zero-x P-256 shared secrets

### DIFF
--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -204,7 +204,16 @@ instance EllipticCurveArith Curve_P256R1 where
 
 instance EllipticCurveDH Curve_P256R1 where
     ecdhRaw _ s p = SharedSecret $ P256.pointDh s p
-    ecdh prx s p = checkNonZeroDH (ecdhRaw prx s p)
+
+    -- An all-zero x-coordinate can be valid. Since P-256's group has prime
+    -- order n, s * P is the identity only when P is the identity or the
+    -- 256-bit scalar s is zero or n.
+    ecdh _ s p
+        | P256.pointIsAtInfinity p
+            || P256.scalarIsZero s
+            || P256.scalarCmp s P256.scalarN == EQ =
+            CryptoFailed CryptoError_ScalarMultiplicationInvalid
+        | otherwise = CryptoPassed $ SharedSecret $ P256.pointDh s p
 
 instance EllipticCurveBasepointArith Curve_P256R1 where
     curveOrderBits _ = 256

--- a/tests/ECC.hs
+++ b/tests/ECC.hs
@@ -9,6 +9,7 @@ import Data.Either
 import qualified Crypto.ECC as ECC
 import Crypto.Error
 
+import Data.ByteArray (convert)
 import Data.ByteArray.Encoding
 
 import Imports
@@ -309,6 +310,32 @@ vectorsWeakPoint =
 vpEncodedPoint :: VectorPoint -> ByteString
 vpEncodedPoint vector = fromRight (error "vpEncodedPoint") $ convertFromBase Base16 (vpHex vector)
 
+-- Wycheproof ecdh_secp256r1_ecpoint_test.json, tcIds 1 and 3.
+vectorsECDH :: [(ByteString, ByteString, ByteString)]
+vectorsECDH =
+    [
+        ( "0612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346"
+        , "0462d5bd3372af75fe85a040715d0f502428e07046868b0bfdfa61d731afe44f26ac333a93a9e70a81cd5a95b5bf8d13990eb741c8c38872b4a07d275a014e30cf"
+        , "53020d908b0219328b658b525f26780e3ae12bcd952bb25a93bc0895e1714285"
+        )
+    ,
+        ( "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a"
+        , "0458fd4168a87795603e2b04390285bdca6e57de6027fe211dd9d25e2212d29e62080d36bd224d7405509295eed02a17150e03b314f96da37445b0d1d29377d12c"
+        , "0000000000000000000000000000000000000000000000000000000000000000"
+        )
+    ]
+
+unhex :: ByteString -> ByteString
+unhex = fromRight (error "unhex") . convertFromBase Base16
+
+doECDHTest :: Show p => p -> (ByteString, ByteString, ByteString) -> TestTree
+doECDHTest i (priv, pub, shared) = testCase (show i) $
+    CryptoPassed (unhex shared) @=? (convert <$> ECC.ecdh prx sk pk)
+  where
+    prx = Just ECC.Curve_P256R1
+    sk = throwCryptoError $ ECC.decodeScalar prx (unhex priv)
+    pk = throwCryptoError $ ECC.decodePoint prx (unhex pub)
+
 cryptoError :: CryptoFailable a -> Maybe CryptoError
 cryptoError = onCryptoFailure Just (const Nothing)
 
@@ -336,6 +363,7 @@ tests =
     testGroup
         "ECC"
         [ testGroup "decodePoint" $ zipWith doPointDecodeTest [katZero ..] vectorsPoint
+        , testGroup "ECDH KATs" $ zipWith doECDHTest [katZero ..] vectorsECDH
         , testGroup "ECDH weak points" $
             zipWith doWeakPointECDHTest [katZero ..] vectorsWeakPoint
         , testGroup


### PR DESCRIPTION
## Summary

Accept valid P-256 ECDH shared secrets whose x-coordinate is zero.

[NIST SP 800-56A Rev. 3, Section 5.7.1.2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf#page=59) requires ECC CDH to reject the result when the computed point is the point at infinity. Otherwise, the shared secret is the encoded x-coordinate.

`Crypto.ECC.ecdh` instead rejected every all-zero P-256 result, conflating the point-at-infinity sentinel with a valid x-coordinate of zero. This was found through [Wycheproof `ecdh_secp256r1_ecpoint_test.json`, tcId 3](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/ecdh_secp256r1_ecpoint_test.json), which is valid and expects a 32-byte all-zero shared secret.

## Changes

- Detect a P-256 identity result from the peer point and scalar instead of the encoded shared secret.
- Return a valid all-zero P-256 shared secret while continuing to reject the point at infinity.
- Add Wycheproof tcId 3 as a regression case, with tcId 1 as a control.

## Tests

- Regression commit: the Wycheproof case fails with `CryptoError_ScalarMultiplicationInvalid` as expected.
- Fix commit and all tests pass.